### PR TITLE
[ENH] Equality dunder for `BaseObject`-s

### DIFF
--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -77,6 +77,24 @@ class BaseObject(_BaseEstimator):
         self._tags_dynamic = {}
         super(BaseObject, self).__init__()
 
+    def __eq__(self, other):
+        """Equality dunder. Checks equal class and parameters.
+
+        Returns True iff result of get_params(deep=False)
+        results in equal parameter sets.
+
+        Nested BaseObject descendants from get_params are compared via __eq__ as well.
+        """
+        from skbase.testing.utils.deep_equals import deep_equals
+
+        if not isinstance(other, BaseObject):
+            return False
+
+        self_params = self.get_params(deep=False)
+        other_params = other.get_params(deep=False)
+
+        return deep_equals(self_params, other_params)
+
     def reset(self):
         """Reset the object to a clean post-init state.
 

--- a/skbase/testing/utils/deep_equals.py
+++ b/skbase/testing/utils/deep_equals.py
@@ -9,8 +9,6 @@ Objects compared can have one of the following valid types:
 from inspect import isclass
 from typing import List
 
-import numpy as np
-
 from skbase.testing.utils._dependencies import _check_soft_dependencies
 
 __author__: List[str] = ["fkiraly"]
@@ -79,7 +77,9 @@ def deep_equals(x, y, return_msg=False):
         if res is not None:
             return _pandas_equals(x, y, return_msg=return_msg)
 
-    if isinstance(x, np.ndarray):
+    if _is_npndarray(x):
+        import numpy as np
+
         if x.dtype != y.dtype:
             return ret(False, f".dtype, x.dtype = {x.dtype} != y.dtype = {y.dtype}")
         return ret(np.array_equal(x, y, equal_nan=True), ".values")
@@ -88,12 +88,6 @@ def deep_equals(x, y, return_msg=False):
         return ret(*_tuple_equals(x, y, return_msg=True))
     elif isinstance(x, dict):
         return ret(*_dict_equals(x, y, return_msg=True))
-    # np.nan returns False when comparing np.nan == np.nan
-    # we deal with this by looking at the type
-    elif isinstance(x, type(np.nan)):
-        return ret(
-            isinstance(y, type(np.nan)), f"type(x)={type(x)} != type(y)={type(y)}"
-        )
     elif isclass(x):
         return ret(x == y, f".class, x={x.__name__} != y={y.__name__}")
     elif type(x).__name__ == "ForecastingHorizon":
@@ -118,6 +112,13 @@ def _is_pandas(x):
         return True
     else:
         return False
+
+
+def _is_npndarray(x):
+
+    clstr = type(x).__name__
+    if clstr in ["ndarray"]:
+        return True
 
 
 def _pandas_equals(x, y, return_msg=False):

--- a/skbase/testing/utils/deep_equals.py
+++ b/skbase/testing/utils/deep_equals.py
@@ -99,10 +99,10 @@ def deep_equals(x, y, return_msg=False):
         return ret(*_fh_equals(x, y, return_msg=True))
     # this elif covers case where != is boolean
     # some types return a vector upon !=, this is covered in the next elif
-    elif isinstance(x != y, bool) and x != y:
-        return ret(False, f" !=, {x} != {y}")
+    elif isinstance(x != y, bool):
+        return ret(x != y, f" !=, {x} != {y}")
     # deal with the case where != returns a vector
-    elif numpy_available and np.any(x != y) or any(x != y):
+    elif numpy_available and np.any(x != y) or any(_coerce_list(x != y)):
         return ret(False, f" !=, {x} != {y}")
 
     return ret(True, "")
@@ -124,6 +124,16 @@ def _is_npndarray(x):
     clstr = type(x).__name__
     if clstr in ["ndarray"]:
         return True
+
+
+def _coerce_list(x):
+    """Coerce x to list."""
+    if not isinstance(x, (list, tuple)):
+        x = [x]
+    if isinstance(x, tuple):
+        x = list(x)
+
+    return x
 
 
 def _pandas_equals(x, y, return_msg=False):

--- a/skbase/testing/utils/deep_equals.py
+++ b/skbase/testing/utils/deep_equals.py
@@ -99,8 +99,8 @@ def deep_equals(x, y, return_msg=False):
         return ret(*_fh_equals(x, y, return_msg=True))
     # this elif covers case where != is boolean
     # some types return a vector upon !=, this is covered in the next elif
-    elif isinstance(x != y, bool):
-        return ret(x != y, f" !=, {x} != {y}")
+    elif isinstance(x == y, bool):
+        return ret(x == y, f" !=, {x} != {y}")
     # deal with the case where != returns a vector
     elif numpy_available and np.any(x != y) or any(_coerce_list(x != y)):
         return ret(False, f" !=, {x} != {y}")

--- a/skbase/testing/utils/deep_equals.py
+++ b/skbase/testing/utils/deep_equals.py
@@ -122,8 +122,7 @@ def _is_pandas(x):
 def _is_npndarray(x):
 
     clstr = type(x).__name__
-    if clstr in ["ndarray"]:
-        return True
+    return clstr == "ndarray"
 
 
 def _coerce_list(x):

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -536,7 +536,9 @@ def test_components(fixture_object, fixture_class_parent, fixture_composition_du
     assert isinstance(comp_comps, dict)
     assert set(comp_comps.keys()) == {"foo_"}
     assert comp_comps["foo_"] == composite.foo_
-    assert comp_comps["foo_"] != composite.foo
+    assert comp_comps["foo_"] is composite.foo_
+    assert comp_comps["foo_"] == composite.foo
+    assert comp_comps["foo_"] is not composite.foo
 
     assert comp_comps == comp_comps_baseobject_filter
     assert comp_comps_filter == {}

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -64,6 +64,7 @@ __all__ = [
     "test_create_test_instance",
     "test_create_test_instances_and_names",
     "test_has_implementation_of",
+    "test_eq_dunder",
 ]
 
 import inspect
@@ -77,7 +78,7 @@ from sklearn import config_context
 # TODO: Update with import of skbase clone function once implemented
 from sklearn.base import clone
 
-from skbase.base import BaseObject
+from skbase.base import BaseEstimator, BaseObject
 
 # TODO: Determine if we need to add sklearn style test of
 # test_set_params_passes_all_parameters
@@ -1036,3 +1037,60 @@ def test_has_implementation_of(
     # If the method is defined the first time in the parent class it should not
     # return _has_implementation_of == True
     assert not fixture_class_parent_instance._has_implementation_of("some_method")
+
+
+class FittableCompositionDummy(BaseEstimator):
+    """Potentially composite object, for testing."""
+
+    def __init__(self, foo, bar=84):
+        self.foo = foo
+        self.foo_ = deepcopy(foo)
+        self.bar = bar
+
+    def fit(self):
+        if hasattr(self.foo_, "fit"):
+            self.foo_.fit()
+        self._is_fitted = True
+
+
+def test_eq_dunder():
+    """Tests equality dunder for BaseObject descendants.
+
+    Equality should be determined only by get_params results.
+
+    Raises
+    ------
+    AssertionError if logic behind __eq__ is incorrect, logic tested:
+        equality of non-composites depends only on params, not on identity
+        equality of composites depends only on params, not on identity
+        result is not affected by fitting the estimator
+    """
+    non_composite = FittableCompositionDummy(foo=42)
+    non_composite_2 = FittableCompositionDummy(foo=42)
+    non_composite_3 = FittableCompositionDummy(foo=84)
+
+    composite = FittableCompositionDummy(foo=non_composite)
+    composite_2 = FittableCompositionDummy(foo=non_composite_2)
+    composite_3 = FittableCompositionDummy(foo=non_composite_3)
+
+    assert non_composite == non_composite
+    assert composite == composite
+    assert non_composite == non_composite_2
+    assert non_composite != non_composite_3
+    assert non_composite_2 != non_composite_3
+    assert composite == composite_2
+    assert composite != composite_3
+    assert composite_2 != composite_3
+
+    # equality should not be affected by fitting
+    composite.fit()
+    non_composite_2.fit()
+
+    assert non_composite == non_composite
+    assert composite == composite
+    assert non_composite == non_composite_2
+    assert non_composite != non_composite_3
+    assert non_composite_2 != non_composite_3
+    assert composite == composite_2
+    assert composite != composite_3
+    assert composite_2 != composite_3

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -1075,6 +1075,7 @@ def test_eq_dunder():
     composite_2 = FittableCompositionDummy(foo=non_composite_2)
     composite_3 = FittableCompositionDummy(foo=non_composite_3)
 
+    # test basic equality - expected equalitiesi as per parameters
     assert non_composite == non_composite
     assert composite == composite
     assert non_composite == non_composite_2
@@ -1084,9 +1085,17 @@ def test_eq_dunder():
     assert composite != composite_3
     assert composite_2 != composite_3
 
-    # equality should not be affected by fitting
+    # test interaction with clone and copy
+    assert non_composite.clone() == non_composite
+    assert composite.clone() == composite
+    assert deepcopy(non_composite) == non_composite
+    assert deepcopy(composite) == composite
+
+    # test that equality is not be affected by fitting
     composite.fit()
     non_composite_2.fit()
+    # composite_2 is an unfitted version of composite
+    # composite is an unfitted version of non_composite_2
 
     assert non_composite == non_composite
     assert composite == composite


### PR DESCRIPTION
Mirrors `sktime` PR https://github.com/sktime/sktime/pull/3862, partial towards #83

Description from `sktime` PR:

This adds an equality dunder to `BaseObject` descendants.

Two `BaseObject` descendants are considered equal if they define the same estimator blueprint, i.e., nested `get_params` result in value-identical dictionaries (with nested call to `__eq__` should those dictionaries contain `BaseObject` descendants).

Includes a test for expected properties of the dunder.

This is prompted by issues of equality testing in tests such as in the failure relevant for https://github.com/sktime/sktime/pull/3857, where equality currently means object identity rather than parameter identity.