### PR TITLE
[ENH] `get_fitted_params` interface for `BaseEstimator`

### DIFF
--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -814,6 +814,11 @@ class BaseEstimator(BaseObject):
     Extends BaseObject to include basic functionality for fittable estimators.
     """
 
+    # tuple of non-BaseObject classes that count as nested objects
+    # get_fitted_params will retrieve parameters from these, too
+    # override in descendant class - common choice: BaseEstimator from sklearn
+    GET_FITTED_PARAMS_NESTING = ()
+
     def __init__(self):
         """Construct BaseEstimator."""
         self._is_fitted = False
@@ -851,3 +856,101 @@ class BaseEstimator(BaseObject):
                 f"This instance of {self.__class__.__name__} has not been fitted yet. "
                 f"Please call `fit` first."
             )
+
+    def get_fitted_params(self):
+        """Get fitted parameters.
+
+        State required:
+            Requires state to be "fitted".
+
+        Returns
+        -------
+        fitted_params : dict of fitted parameters, keys are str names of parameters
+            parameters of components are indexed as [componentname]__[paramname]
+        """
+        if not self.is_fitted:
+            raise NotFittedError(
+                f"estimator of type {type(self).__name__} has not been "
+                "fitted yet, please call fit on data before get_fitted_params"
+            )
+
+        fitted_params = dict()
+
+        def sh(x):
+            """Shorthand to remove all underscores at end of a string."""
+            if x.endswith("_"):
+                return sh(x[:-1])
+            else:
+                return x
+
+        # add all nested parameters from components that are sktime BaseObject
+        c_dict = self._components()
+        for c, comp in c_dict.items():
+            if isinstance(comp, BaseEstimator) and comp._is_fitted:
+                c_f_params = comp.get_fitted_params()
+                c_f_params = {f"{sh(c)}__{k}": v for k, v in c_f_params.items()}
+                fitted_params.update(c_f_params)
+
+        # add non-nested fitted params of self
+        fitted_params.update(self._get_fitted_params())
+
+        # add all nested parameters from components that are sklearn estimators
+        # we do this recursively as we have to reach into nested sklearn estimators
+        n_new_params = 42
+        old_new_params = fitted_params
+        while n_new_params > 0:
+            new_params = dict()
+            for c, comp in old_new_params.items():
+                if isinstance(comp, self.GET_FITTED_PARAMS_NESTING):
+                    c_f_params = self._get_fitted_params_default(comp)
+                    c_f_params = {f"{sh(c)}__{k}": v for k, v in c_f_params.items()}
+                    new_params.update(c_f_params)
+            fitted_params.update(new_params)
+            old_new_params = new_params.copy()
+            n_new_params = len(new_params)
+
+        return fitted_params
+
+    def _get_fitted_params_default(self, obj=None):
+        """Obtain fitted params of object, per sklearn convention.
+
+        Extracts a dict with {paramstr : paramvalue} contents,
+        where paramstr are all string names of "fitted parameters".
+
+        A "fitted attribute" of obj is one that ends in "_" but does not start with "_".
+        "fitted parameters" are names of fitted attributes, minus the "_" at the end.
+
+        Parameters
+        ----------
+        obj : any object, optional, default=self
+
+        Returns
+        -------
+        fitted_params : dict with str keys
+            fitted parameters, keyed by names of fitted parameter
+        """
+        obj = obj if obj else self
+
+        # default retrieves all self attributes ending in "_"
+        # and returns them with keys that have the "_" removed
+        fitted_params = [attr for attr in dir(obj) if attr.endswith("_")]
+        fitted_params = [x for x in fitted_params if not x.startswith("_")]
+        fitted_params = [x for x in fitted_params if hasattr(obj, x)]
+        fitted_param_dict = {p[:-1]: getattr(obj, p) for p in fitted_params}
+
+        return fitted_param_dict
+
+    def _get_fitted_params(self):
+        """Get fitted parameters.
+
+        private _get_fitted_params, called from get_fitted_params
+
+        State required:
+            Requires state to be "fitted".
+
+        Returns
+        -------
+        fitted_params : dict with str keys
+            fitted parameters, keyed by names of fitted parameter
+        """
+        return self._get_fitted_params_default()

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -883,7 +883,7 @@ class BaseEstimator(BaseObject):
             else:
                 return x
 
-        # add all nested parameters from components that are sktime BaseObject
+        # add all nested parameters from components that are skbase BaseEstimator
         c_dict = self._components()
         for c, comp in c_dict.items():
             if isinstance(comp, BaseEstimator) and comp._is_fitted:
@@ -896,7 +896,7 @@ class BaseEstimator(BaseObject):
 
         # add all nested parameters from components that are sklearn estimators
         # we do this recursively as we have to reach into nested sklearn estimators
-        n_new_params = 42
+        n_new_params = 42  # dummy value so the "while" condition is True 1st time
         old_new_params = fitted_params
         while n_new_params > 0:
             new_params = {}

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -874,7 +874,7 @@ class BaseEstimator(BaseObject):
                 "fitted yet, please call fit on data before get_fitted_params"
             )
 
-        fitted_params = dict()
+        fitted_params = {}
 
         def sh(x):
             """Shorthand to remove all underscores at end of a string."""
@@ -899,7 +899,7 @@ class BaseEstimator(BaseObject):
         n_new_params = 42
         old_new_params = fitted_params
         while n_new_params > 0:
-            new_params = dict()
+            new_params = {}
             for c, comp in old_new_params.items():
                 if isinstance(comp, self.GET_FITTED_PARAMS_NESTING):
                     c_f_params = self._get_fitted_params_default(comp)

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -935,10 +935,15 @@ class BaseEstimator(BaseObject):
 
         # default retrieves all self attributes ending in "_"
         # and returns them with keys that have the "_" removed
-        fitted_params = [attr for attr in dir(obj) if attr.endswith("_")]
-        fitted_params = [x for x in fitted_params if not x.startswith("_")]
-        fitted_params = [x for x in fitted_params if hasattr(obj, x)]
-        fitted_param_dict = {p[:-1]: getattr(obj, p) for p in fitted_params}
+        #
+        # get all attributes ending in "_", exclude any that start with "_" (private)
+        fitted_params = [
+            attr for attr in dir(obj) if attr.endswith("_") and not attr.startswith("_")
+        ]
+        # remove the "_" at the end
+        fitted_param_dict = {
+            p[:-1]: getattr(obj, p) for p in fitted_params if hasattr(obj, p)
+        }
 
         return fitted_param_dict
 

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -896,9 +896,10 @@ class BaseEstimator(BaseObject):
 
         # add all nested parameters from components that are sklearn estimators
         # we do this recursively as we have to reach into nested sklearn estimators
-        n_new_params = 42  # dummy value so the "while" condition is True 1st time
+        any_components_left_to_process = True
         old_new_params = fitted_params
-        while n_new_params > 0:
+        # this loop recursively and iteratively processes components inside components
+        while any_components_left_to_process:
             new_params = {}
             for c, comp in old_new_params.items():
                 if isinstance(comp, self.GET_FITTED_PARAMS_NESTING):
@@ -908,6 +909,7 @@ class BaseEstimator(BaseObject):
             fitted_params.update(new_params)
             old_new_params = new_params.copy()
             n_new_params = len(new_params)
+            any_components_left_to_process = n_new_params > 0
 
         return fitted_params
 

--- a/skbase/tests/test_baseestimator.py
+++ b/skbase/tests/test_baseestimator.py
@@ -118,9 +118,9 @@ def test_get_fitted_params():
     comp_f_params = composite.get_fitted_params()
 
     assert isinstance(non_comp_f_params, dict)
-    assert set(non_comp_f_params.keys()) == set(["foo"])
+    assert set(non_comp_f_params.keys()) == {"foo"}
 
     assert isinstance(comp_f_params, dict)
-    assert set(comp_f_params) == set(["foo", "foo__foo"])
+    assert set(comp_f_params) == {"foo", "foo__foo"}
     assert comp_f_params["foo"] is composite.foo_
     assert comp_f_params["foo"] is not composite.foo


### PR DESCRIPTION
Uniform `get_fitted_params` interface for `BaseEstimator`, including tests.
Partially addresses #83.

Related `sktime` issues and PR:
* https://github.com/sktime/sktime/issues/971
* https://github.com/sktime/sktime/pull/3077
* https://github.com/sktime/sktime/issues/3381
* https://github.com/sktime/sktime/pull/3598
* https://github.com/sktime/sktime/issues/3645