### PR TITLE
[MNT] bump `sklearn` upper bound to `<1.3.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 requires-python = ">=3.7,<3.12"
 dependencies = [
-    "scikit-learn>=0.24.0,<1.2.0", "typing-extensions", "pytest"
+    "scikit-learn>=0.24.0,<1.3.0", "typing-extensions", "pytest"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 requires-python = ">=3.7,<3.12"
 dependencies = [
-    "scikit-learn>=0.24.0", "typing-extensions", "pytest"
+    "scikit-learn>=0.24.0,<1.3.0", "typing-extensions", "pytest"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 requires-python = ">=3.7,<3.12"
 dependencies = [
-    "scikit-learn>=0.24.0,<1.3.0", "typing-extensions", "pytest"
+    "scikit-learn>=0.24.0", "typing-extensions", "pytest"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Bumps the upper `sklearn` requirement bound to `<1.3.0`.

Surely nothing bad will happen.