### PR TITLE
[ENH] Improve error messages in `test_object_tags` test

### DIFF
--- a/skbase/testing/test_all_objects.py
+++ b/skbase/testing/test_all_objects.py
@@ -581,9 +581,7 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
             )
             assert isinstance(tags, dict), msg
             assert len(tags) > 0, f"_tags dict of class {object_class} is empty"
-            invalid_tags = [
-                tag for tag in tags.keys() if tag not in self.valid_tags
-            ]
+            invalid_tags = [tag for tag in tags.keys() if tag not in self.valid_tags]
             assert len(invalid_tags) == 0, (
                 f"_tags of {object_class} contains invalid tags: {invalid_tags}. "
                 f"For a list of valid tags, see {self.__name__}.valid_tags. "

--- a/skbase/testing/test_all_objects.py
+++ b/skbase/testing/test_all_objects.py
@@ -575,13 +575,19 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         assert all(isinstance(key, str) for key in all_tags.keys())
         if hasattr(object_class, "_tags"):
             tags = object_class._tags
-            msg = f"_tags must be a dict, but found {type(tags)}"
+            msg = (
+                f"_tags attribute of class {object_class} must be dict, "
+                f"but found {type(tags)}"
+            )
             assert isinstance(tags, dict), msg
-            assert len(tags) > 0, "_tags is empty"
-            if self.valid_tags is not None:
-                assert all(
-                    tag in self.valid_tags for tag in tags.keys()
-                ), "Some tags in _tags are invalid"
+            assert len(tags) > 0, f"_tags dict of class {object_class} is empty"
+            invalid_tags = [
+                tag for tag in tags.keys() if tag not in self.valid_tags
+            ]
+            assert len(invalid_tags) == 0, (
+                f"_tags of {object_class} contains invalid tags: {invalid_tags}. "
+                f"For a list of valid tags, see {self.__name__}.valid_tags. "
+            )
 
         # Avoid ambiguous class attributes
         ambiguous_attrs = ("tags", "tags_")


### PR DESCRIPTION
This PR improves error messages in the `test_object_tags` interface contract test, adding the source class and specific reasons for failures.

Ports https://github.com/sktime/sktime/pull/4014