### PR TITLE
Convert about page to sphinx-design

### DIFF
--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -17,89 +17,107 @@ Learn more about the ``skbase`` project and its community.
    about/governance
    about/roadmap
 
-.. panels::
-    :card: + intro-card text-center
+.. grid:: 1 2 2 2
+    :gutter: 3
 
-    ---
+    .. grid-item-card::
+        :text-align: center
 
-    Mission
-    ^^^^^^^
+        Mission
+        ^^^^^^^
 
-    ``skbase's`` mission.
+        ``skbase``'s mission.
 
-    +++
+        +++
 
-    .. link-button:: about/mission
-            :type: ref
-            :text: Mission
-            :classes: btn-block btn-secondary stretched-link
+        .. button-ref:: about/mission
+            :color: primary
+            :click-parent:
+            :expand:
 
-    ---
+            Mission
 
-    History
-    ^^^^^^^
+    .. grid-item-card::
+        :text-align: center
 
-    Learn about ``skbase's`` history.
+        History
+        ^^^^^^^
 
-    +++
+        Learn about ``skbase``'s history.
 
-    .. link-button:: about/history
-            :type: ref
-            :text: History
-            :classes: btn-block btn-secondary stretched-link
+        +++
 
-    ---
+        .. button-ref:: about/history
+            :color: primary
+            :click-parent:
+            :expand:
 
-    Development Team
-    ^^^^^^^^^^^^^^^^
+            History
 
-    ``skbase's`` core development team.
+    .. grid-item-card::
+        :text-align: center
 
-    +++
+        Development Team
+        ^^^^^^^^^^^^^^^^
 
-    .. link-button:: about/team
-            :type: ref
-            :text: Development Team
-            :classes: btn-block btn-secondary stretched-link
+        ``skbase``'s core development team.
 
-    ---
+        +++
 
-    Contributors
-    ^^^^^^^^^^^^
+        .. button-ref:: about/team
+            :color: primary
+            :click-parent:
+            :expand:
 
-    All of ``skbase's`` contributors.
+            Development Team
 
-    +++
+    .. grid-item-card::
+        :text-align: center
 
-    .. link-button:: about/contributors
-            :type: ref
-            :text: Contributors
-            :classes: btn-block btn-secondary stretched-link
+        Contributors
+        ^^^^^^^^^^^^
 
-    ---
+        All of ``skbase``'s contributors.
 
-    Governance
-    ^^^^^^^^^^
+        +++
 
-    How we govern the project.
+        .. button-ref:: about/contributors
+            :color: primary
+            :click-parent:
+            :expand:
 
-    +++
+            Contributors
 
-    .. link-button:: about/governance
-            :type: ref
-            :text: Governance
-            :classes: btn-block btn-secondary stretched-link
+    .. grid-item-card::
+        :text-align: center
 
-    ---
+        Governance
+        ^^^^^^^^^^
 
-    Roadmap
-    ^^^^^^^
+        How we govern the project.
 
-    Planned Development.
+        +++
 
-    +++
+        .. button-ref:: about/governance
+            :color: primary
+            :click-parent:
+            :expand:
 
-    .. link-button:: about/roadmap
-            :type: ref
-            :text: Roadmap
-            :classes: btn-block btn-secondary stretched-link
+            Governance
+
+    .. grid-item-card::
+        :text-align: center
+
+        Roadmap
+        ^^^^^^^
+
+        Where we plan to take ``skbase``.
+
+        +++
+
+        .. button-ref:: about/roadmap
+            :color: primary
+            :click-parent:
+            :expand:
+
+            Roadmap

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -20,11 +20,8 @@ Learn more about the ``skbase`` project and its community.
 .. grid:: 1 2 2 2
     :gutter: 3
 
-    .. grid-item-card::
+    .. grid-item-card:: Mission
         :text-align: center
-
-        Mission
-        ^^^^^^^
 
         ``skbase``'s mission.
 
@@ -37,11 +34,8 @@ Learn more about the ``skbase`` project and its community.
 
             Mission
 
-    .. grid-item-card::
+    .. grid-item-card:: History
         :text-align: center
-
-        History
-        ^^^^^^^
 
         Learn about ``skbase``'s history.
 
@@ -54,11 +48,8 @@ Learn more about the ``skbase`` project and its community.
 
             History
 
-    .. grid-item-card::
+    .. grid-item-card:: Development Team
         :text-align: center
-
-        Development Team
-        ^^^^^^^^^^^^^^^^
 
         ``skbase``'s core development team.
 
@@ -71,11 +62,8 @@ Learn more about the ``skbase`` project and its community.
 
             Development Team
 
-    .. grid-item-card::
+    .. grid-item-card:: Contributors
         :text-align: center
-
-        Contributors
-        ^^^^^^^^^^^^
 
         All of ``skbase``'s contributors.
 
@@ -88,11 +76,8 @@ Learn more about the ``skbase`` project and its community.
 
             Contributors
 
-    .. grid-item-card::
+    .. grid-item-card:: Governance
         :text-align: center
-
-        Governance
-        ^^^^^^^^^^
 
         How we govern the project.
 
@@ -105,11 +90,8 @@ Learn more about the ``skbase`` project and its community.
 
             Governance
 
-    .. grid-item-card::
+    .. grid-item-card:: Roadmap
         :text-align: center
-
-        Roadmap
-        ^^^^^^^
 
         Where we plan to take ``skbase``.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,10 @@ extensions = [
     "myst_parser",
     "sphinx_panels",
     "sphinx_issues",
+    "sphinx_design",
 ]
+
+myst_enable_extensions = ["colon_fence"]
 
 # -- Internationalization ------------------------------------------------
 # specifying the natural language populates some key tags

--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -16,61 +16,73 @@ get stuck, please don't hesitate to chat with us or raise an issue.
    contribute/team
    contribute/code_of_conduct
 
-.. panels::
-    :card: + intro-card text-center
+.. grid:: 1 2 2 2
+    :gutter: 2
 
-    ---
+    .. grid-item-card::
+        :text-align: center
 
-    How to contribute
-    ^^^^^^^^^^^^^^^^^
+        How to contribute
+        ^^^^^^^^^^^^^^^^^
 
-    New to ``skbase``? Learn how you can contribute.
+        New to ``skbase``? Learn how you can contribute.
 
-    +++
+        +++
 
-    .. link-button:: contribute/how_to_contribute
-            :type: ref
-            :text: Contribute
-            :classes: btn-block btn-secondary stretched-link
+        .. button-ref:: contribute/how_to_contribute
+            :color: primary
+            :click-parent:
+            :expand:
 
-    ---
+            Contribute
 
-    Development
-    ^^^^^^^^^^^
+    .. grid-item-card::
+        :text-align: center
 
-    Help develop ``skbase``.
+        Development
+        ^^^^^^^^^^^
 
-    +++
+        Help develop ``skbase``.
 
-    .. link-button:: contribute/development
-            :type: ref
-            :text: Development
-            :classes: btn-block btn-secondary stretched-link
+        +++
 
-    ---
+        .. button-ref:: contribute/development
+            :color: primary
+            :click-parent:
+            :expand:
 
-    Development Team
-    ^^^^^^^^^^^^^^^^
+            Development
 
-    Meet ``skbase's`` core development team.
+    .. grid-item-card::
+        :text-align: center
 
-    +++
+        Development Team
+        ^^^^^^^^^^^^^^^^
 
-    .. link-button:: contribute/team
-            :type: ref
-            :text: Development Team
-            :classes: btn-block btn-secondary stretched-link
+        Meet ``skbase``'score development team.
 
-    ---
+        +++
 
-    Code of Conduct
-    ^^^^^^^^^^^^^^^
+        .. button-ref:: contribute/team
+            :color: primary
+            :click-parent:
+            :expand:
 
-    Understand our code of conduct.
+            Development Team
 
-    +++
+    .. grid-item-card::
+        :text-align: center
 
-    .. link-button:: contribute/code_of_conduct
-            :type: ref
-            :text: Code of Conduct
-            :classes: btn-block btn-secondary stretched-link
+        Code of Conduct
+        ^^^^^^^^^^^^^^^
+
+        Understand our code of conduct.
+
+        +++
+
+        .. button-ref:: contribute/code_of_conduct
+            :color: primary
+            :click-parent:
+            :expand:
+
+            Code of Conduct

--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -17,7 +17,7 @@ get stuck, please don't hesitate to chat with us or raise an issue.
    contribute/code_of_conduct
 
 .. grid:: 1 2 2 2
-    :gutter: 2
+    :gutter: 3
 
     .. grid-item-card::
         :text-align: center

--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -19,11 +19,8 @@ get stuck, please don't hesitate to chat with us or raise an issue.
 .. grid:: 1 2 2 2
     :gutter: 3
 
-    .. grid-item-card::
+    .. grid-item-card:: How to Contribute
         :text-align: center
-
-        How to contribute
-        ^^^^^^^^^^^^^^^^^
 
         New to ``skbase``? Learn how you can contribute.
 
@@ -36,11 +33,8 @@ get stuck, please don't hesitate to chat with us or raise an issue.
 
             Contribute
 
-    .. grid-item-card::
+    .. grid-item-card:: Development
         :text-align: center
-
-        Development
-        ^^^^^^^^^^^
 
         Help develop ``skbase``.
 
@@ -53,11 +47,8 @@ get stuck, please don't hesitate to chat with us or raise an issue.
 
             Development
 
-    .. grid-item-card::
+    .. grid-item-card:: Development Team
         :text-align: center
-
-        Development Team
-        ^^^^^^^^^^^^^^^^
 
         Meet ``skbase``'score development team.
 
@@ -70,11 +61,8 @@ get stuck, please don't hesitate to chat with us or raise an issue.
 
             Development Team
 
-    .. grid-item-card::
+    .. grid-item-card:: Code of Conduct
         :text-align: center
-
-        Code of Conduct
-        ^^^^^^^^^^^^^^^
 
         Understand our code of conduct.
 

--- a/docs/source/contribute/development.rst
+++ b/docs/source/contribute/development.rst
@@ -17,7 +17,7 @@ Development
    development/contrib_governance
 
 .. grid:: 1 2 2 2
-    :gutter: 2
+    :gutter: 3
 
     .. grid-item-card::
         :text-align: center

--- a/docs/source/contribute/development.rst
+++ b/docs/source/contribute/development.rst
@@ -19,11 +19,8 @@ Development
 .. grid:: 1 2 2 2
     :gutter: 3
 
-    .. grid-item-card::
+    .. grid-item-card:: Developer Guide
         :text-align: center
-
-        Developer Guide
-        ^^^^^^^^^^^^^^^
 
         Learn our development conventions.
 
@@ -36,11 +33,8 @@ Development
 
             Developer Guide
 
-    .. grid-item-card::
+    .. grid-item-card:: Reviewer Guide
         :text-align: center
-
-        Reviewer Guide
-        ^^^^^^^^^^^^^^
 
         How we review contributions.
 
@@ -53,11 +47,8 @@ Development
 
             Reviewer Guide
 
-    .. grid-item-card::
+    .. grid-item-card:: Roadmap
         :text-align: center
-
-        Roadmap
-        ^^^^^^^
 
         What's on our development horizon.
 
@@ -70,11 +61,8 @@ Development
 
             Roadmap
 
-    .. grid-item-card::
+    .. grid-item-card:: Governance
         :text-align: center
-
-        Governance
-        ^^^^^^^^^^
 
         Understand our code of conduct.
 

--- a/docs/source/contribute/development.rst
+++ b/docs/source/contribute/development.rst
@@ -16,61 +16,73 @@ Development
    development/contrib_roadmap
    development/contrib_governance
 
-.. panels::
-    :card: + intro-card text-center
+.. grid:: 1 2 2 2
+    :gutter: 2
 
-    ---
+    .. grid-item-card::
+        :text-align: center
 
-    Developer Guide
-    ^^^^^^^^^^^^^^^
+        Developer Guide
+        ^^^^^^^^^^^^^^^
 
-    Learn our development conventions.
+        Learn our development conventions.
 
-    +++
+        +++
 
-    .. link-button:: development/developer_guide
-            :type: ref
-            :text: Developer Guide
-            :classes: btn-block btn-secondary stretched-link
+        .. button-ref:: development/developer_guide
+            :color: primary
+            :click-parent:
+            :expand:
 
-    ---
+            Developer Guide
 
-    Reviewer Guide
-    ^^^^^^^^^^^^^^
+    .. grid-item-card::
+        :text-align: center
 
-    How we review contributions.
+        Reviewer Guide
+        ^^^^^^^^^^^^^^
 
-    +++
+        How we review contributions.
 
-    .. link-button:: development/reviewer_guide
-            :type: ref
-            :text: Reviewer Guide
-            :classes: btn-block btn-secondary stretched-link
+        +++
 
-    ---
+        .. button-ref:: development/reviewer_guide
+            :color: primary
+            :click-parent:
+            :expand:
 
-    Roadmap
-    ^^^^^^^
+            Reviewer Guide
 
-    What's on our development horizon.
+    .. grid-item-card::
+        :text-align: center
 
-    +++
+        Roadmap
+        ^^^^^^^
 
-    .. link-button:: development/contrib_roadmap
-            :type: ref
-            :text: Roadmap
-            :classes: btn-block btn-secondary stretched-link
+        What's on our development horizon.
 
-    ---
+        +++
 
-    Governance
-    ^^^^^^^^^^
+        .. button-ref:: development/contrib_roadmap
+            :color: primary
+            :click-parent:
+            :expand:
 
-    Understand our code of conduct.
+            Roadmap
 
-    +++
+    .. grid-item-card::
+        :text-align: center
 
-    .. link-button:: development/contrib_governance
-            :type: ref
-            :text: Governance
-            :classes: btn-block btn-secondary stretched-link
+        Governance
+        ^^^^^^^^^^
+
+        Understand our code of conduct.
+
+        +++
+
+        .. button-ref:: development/contrib_governance
+            :color: primary
+            :click-parent:
+            :expand:
+
+            Governance

--- a/docs/source/contribute/development/developer_guide.rst
+++ b/docs/source/contribute/development/developer_guide.rst
@@ -18,13 +18,10 @@ Developer guide
    developer_guide/enhancement_proposal
 
 .. grid:: 1 2 2 2
-    :gutter: 2
+    :gutter: 3
 
-    .. grid-item-card::
+    .. grid-item-card:: Installation
         :text-align: center
-
-        Installation
-        ^^^^^^^^^^^^
 
         Install a development version of ``skbase``.
 

--- a/docs/source/contribute/development/developer_guide.rst
+++ b/docs/source/contribute/development/developer_guide.rst
@@ -34,11 +34,8 @@ Developer guide
 
             Installation
 
-    .. grid-item-card::
+    .. grid-item-card:: Git Workflow
         :text-align: center
-
-        Git Workflow
-        ^^^^^^^^^^^^
 
         Our Git and Github workflow.
 
@@ -51,11 +48,8 @@ Developer guide
 
             Git and Github Workflow
 
-    .. grid-item-card::
+    .. grid-item-card:: Continuous Integration
         :text-align: center
-
-        Continuous Integration
-        ^^^^^^^^^^^^^^^^^^^^^^
 
         Continuous Integration.
 
@@ -68,11 +62,8 @@ Developer guide
 
             Continuous Integration
 
-    .. grid-item-card::
+    .. grid-item-card:: Coding Standards
         :text-align: center
-
-        Coding Standards
-        ^^^^^^^^^^^^^^^^
 
         Our code requirements.
 
@@ -85,11 +76,8 @@ Developer guide
 
             Coding Standards
 
-    .. grid-item-card::
+    .. grid-item-card:: Documentation Standards
         :text-align: center
-
-        Documentation Standards
-        ^^^^^^^^^^^^^^^^^^^^^^^
 
         Our documentation requirements.
 
@@ -100,13 +88,10 @@ Developer guide
             :click-parent:
             :expand:
 
-            Documentation StandardsCoding Standards
+            Documentation Standards
 
-    .. grid-item-card::
+    .. grid-item-card:: Testing Framework
         :text-align: center
-
-        Testing Framework
-        ^^^^^^^^^^^^^^^^^
 
         How we test ``skbase``.
 
@@ -119,11 +104,8 @@ Developer guide
 
             Testing Framework
 
-    .. grid-item-card::
+    .. grid-item-card:: Dependency Management
         :text-align: center
-
-        Dependency Management
-        ^^^^^^^^^^^^^^^^^^^^^
 
         How we manage dependencies
 
@@ -136,11 +118,8 @@ Developer guide
 
             Dependencies
 
-    .. grid-item-card::
+    .. grid-item-card:: Proposing Enhancements
         :text-align: center
-
-        Proposing Enhancements
-        ^^^^^^^^^^^^^^^^^^^^^^
 
         How to propose a major change
 

--- a/docs/source/contribute/development/developer_guide.rst
+++ b/docs/source/contribute/development/developer_guide.rst
@@ -17,117 +17,141 @@ Developer guide
    developer_guide/dependencies
    developer_guide/enhancement_proposal
 
-.. panels::
-    :card: + intro-card text-center
+.. grid:: 1 2 2 2
+    :gutter: 2
 
-    ---
+    .. grid-item-card::
+        :text-align: center
 
-    Installation
-    ^^^^^^^^^^^^
+        Installation
+        ^^^^^^^^^^^^
 
-    Install a development version of ``skbase``.
+        Install a development version of ``skbase``.
 
-    +++
+        +++
 
-    .. link-button:: developer_guide/dev_installation
-            :type: ref
-            :text: Installation
-            :classes: btn-block btn-secondary stretched-link
+        .. button-ref:: developer_guide/dev_installation
+            :color: primary
+            :click-parent:
+            :expand:
 
-    ---
+            Installation
 
-    Git Workflow
-    ^^^^^^^^^^^^
+    .. grid-item-card::
+        :text-align: center
 
-    Our Git and Github workflow.
+        Git Workflow
+        ^^^^^^^^^^^^
 
-    +++
+        Our Git and Github workflow.
 
-    .. link-button:: developer_guide/git_workflow
-            :type: ref
-            :text: Git and Github Workflow
-            :classes: btn-block btn-secondary stretched-link
+        +++
 
-    ---
+        .. button-ref:: developer_guide/git_workflow
+            :color: primary
+            :click-parent:
+            :expand:
 
-    Continuous Integration
-    ^^^^^^^^^^^^^^^^^^^^^^
+            Git and Github Workflow
 
-    Continuous Integration.
+    .. grid-item-card::
+        :text-align: center
 
-    +++
+        Continuous Integration
+        ^^^^^^^^^^^^^^^^^^^^^^
 
-    .. link-button:: developer_guide/ci
-            :type: ref
-            :text: Continuous Integration
-            :classes: btn-block btn-secondary stretched-link
+        Continuous Integration.
 
-    ---
+        +++
 
-    Coding Standards
-    ^^^^^^^^^^^^^^^^
+        .. button-ref:: developer_guide/ci
+            :color: primary
+            :click-parent:
+            :expand:
 
-    Our code requirements.
+            Continuous Integration
 
-    +++
+    .. grid-item-card::
+        :text-align: center
 
-    .. link-button:: developer_guide/coding_standards
-            :type: ref
-            :text: Coding Standards
-            :classes: btn-block btn-secondary stretched-link
+        Coding Standards
+        ^^^^^^^^^^^^^^^^
 
-    ---
+        Our code requirements.
 
-    Documentation Standards
-    ^^^^^^^^^^^^^^^^^^^^^^^
+        +++
 
-    Our documentation requirements.
+        .. button-ref:: developer_guide/coding_standards
+            :color: primary
+            :click-parent:
+            :expand:
 
-    +++
+            Coding Standards
 
-    .. link-button:: developer_guide/creating_docs
-            :type: ref
-            :text: Documentation Standards
-            :classes: btn-block btn-secondary stretched-link
+    .. grid-item-card::
+        :text-align: center
 
-    ---
+        Documentation Standards
+        ^^^^^^^^^^^^^^^^^^^^^^^
 
-    Testing Framework
-    ^^^^^^^^^^^^^^^^^
+        Our documentation requirements.
 
-    How we test ``skbase``.
+        +++
 
-    +++
+        .. button-ref:: developer_guide/creating_docs
+            :color: primary
+            :click-parent:
+            :expand:
 
-    .. link-button:: developer_guide/testing_framework
-            :type: ref
-            :text: Testing Framework
-            :classes: btn-block btn-secondary stretched-link
+            Documentation StandardsCoding Standards
 
-    ---
+    .. grid-item-card::
+        :text-align: center
 
-    Dependency Management
-    ^^^^^^^^^^^^^^^^^^^^^
+        Testing Framework
+        ^^^^^^^^^^^^^^^^^
 
-    How we manage dependencies
+        How we test ``skbase``.
 
-    +++
+        +++
 
-    .. link-button:: developer_guide/dependencies
-            :type: ref
-            :text: Dependencies
-            :classes: btn-block btn-secondary stretched-link
+        .. button-ref:: developer_guide/testing_framework
+            :color: primary
+            :click-parent:
+            :expand:
 
-    ---
+            Testing Framework
 
-    Proposing Enhancements
-    ^^^^^^^^^^^^^^^^^^^^^^
+    .. grid-item-card::
+        :text-align: center
 
-    How to propose a major change
+        Dependency Management
+        ^^^^^^^^^^^^^^^^^^^^^
 
-    +++
+        How we manage dependencies
 
-    .. link-button:: developer_guide/enhancement_proposal
-            :type: ref
-            :text: Proposing Enhancements
-            :classes: btn-block btn-secondary stretched-link
+        +++
+
+        .. button-ref:: developer_guide/dependencies
+            :color: primary
+            :click-parent:
+            :expand:
+
+            Dependencies
+
+    .. grid-item-card::
+        :text-align: center
+
+        Proposing Enhancements
+        ^^^^^^^^^^^^^^^^^^^^^^
+
+        How to propose a major change
+
+        +++
+
+        .. button-ref:: developer_guide/enhancement_proposal
+            :color: primary
+            :click-parent:
+            :expand:
+
+            Proposing Enhancements

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,11 +24,8 @@ From here, you can navigate to:
 .. grid:: 1 2 2 2
     :gutter: 3
 
-    .. grid-item-card::
+    .. grid-item-card:: Get Started
         :text-align: center
-
-        Get Started
-        ^^^^^^^^^^^
 
         Get started using ``skbase`` quickly.
 
@@ -41,11 +38,8 @@ From here, you can navigate to:
 
             Get Started
 
-    .. grid-item-card::
+    .. grid-item-card:: User Documentation
         :text-align: center
-
-        User Documentation
-        ^^^^^^^^^^^^^^^^^^
 
         Find user documentation.
 
@@ -58,11 +52,8 @@ From here, you can navigate to:
 
             Users
 
-    .. grid-item-card::
+    .. grid-item-card:: API Reference
         :text-align: center
-
-        API Reference
-        ^^^^^^^^^^^^^
 
         Understand ``skbase``'s API.
 
@@ -75,11 +66,8 @@ From here, you can navigate to:
 
             API Reference
 
-    .. grid-item-card::
+    .. grid-item-card:: Get Involved
         :text-align: center
-
-        Get Involved
-        ^^^^^^^^^^^^
 
         Find out how you can contribute.
 
@@ -92,11 +80,8 @@ From here, you can navigate to:
 
             Get Involved
 
-    .. grid-item-card::
+    .. grid-item-card:: About
         :text-align: center
-
-        About
-        ^^^^^
 
         Learn more about ``skbase``.
 
@@ -109,13 +94,10 @@ From here, you can navigate to:
 
             Learn More
 
-    .. grid-item-card::
+    .. grid-item-card:: Changelog
         :text-align: center
 
-    Changelog
-    ^^^^^^^^^
-
-    See how the package has changed.
+        See how the package has changed.
 
         +++
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,89 +21,107 @@ that follow these design patterns.
 
 From here, you can navigate to:
 
-.. panels::
-    :card: + intro-card text-center
+.. grid:: 1 2 2 2
+    :gutter: 2
 
-    ---
+    .. grid-item-card::
+        :text-align: center
 
-    Get Started
-    ^^^^^^^^^^^
+        Get Started
+        ^^^^^^^^^^^
 
-    Get started using ``skbase`` quickly.
+        Get started using ``skbase`` quickly.
 
-    +++
+        +++
 
-    .. link-button:: get_started
-            :type: ref
-            :text: Get Started
-            :classes: btn-block btn-secondary stretched-link
+        .. button-ref:: get_started
+            :color: primary
+            :click-parent:
+            :expand:
 
-    ---
+            Get Started
 
-    User Documentation
-    ^^^^^^^^^^^^^^^^^^
+    .. grid-item-card::
+        :text-align: center
 
-    Find user documentation.
+        User Documentation
+        ^^^^^^^^^^^^^^^^^^
 
-    +++
+        Find user documentation.
 
-    .. link-button:: users
-            :type: ref
-            :text: Users
-            :classes: btn-block btn-secondary stretched-link
+        +++
 
-    ---
+        .. button-ref:: users
+            :color: primary
+            :click-parent:
+            :expand:
 
-    API Reference
-    ^^^^^^^^^^^^^
+            Users
 
-    Understand ``skbase``'s API.
+    .. grid-item-card::
+        :text-align: center
 
-    +++
+        API Reference
+        ^^^^^^^^^^^^^
 
-    .. link-button:: api_reference
-            :type: ref
-            :text: API Reference
-            :classes: btn-block btn-secondary stretched-link
+        Understand ``skbase``'s API.
 
-    ---
+        +++
 
-    Get Involved
-    ^^^^^^^^^^^^
+        .. button-ref:: api_reference
+            :color: primary
+            :click-parent:
+            :expand:
 
-    Find out how you can contribute.
+            API Reference
 
-    +++
+    .. grid-item-card::
+        :text-align: center
 
-    .. link-button:: contribute
-            :type: ref
-            :text: Get Involved
-            :classes: btn-block btn-secondary stretched-link
+        Get Involved
+        ^^^^^^^^^^^^
 
-    ---
+        Find out how you can contribute.
 
-    About
-    ^^^^^
+        +++
 
-    Learn more about ``skbase``.
+        .. button-ref:: contribute
+            :color: primary
+            :click-parent:
+            :expand:
 
-    +++
+            Get Involved
 
-    .. link-button:: about
-            :type: ref
-            :text: Learn More
-            :classes: btn-block btn-secondary stretched-link
+    .. grid-item-card::
+        :text-align: center
 
-    ---
+        About
+        ^^^^^
+
+        Learn more about ``skbase``.
+
+        +++
+
+        .. button-ref:: about
+            :color: primary
+            :click-parent:
+            :expand:
+
+            Learn More
+
+    .. grid-item-card::
+        :text-align: center
 
     Changelog
     ^^^^^^^^^
 
     See how the package has changed.
 
-    +++
+        +++
 
-    .. link-button:: changelog
-            :type: ref
-            :text: Changelog
-            :classes: btn-block btn-secondary stretched-link
+        .. button-ref:: changelog
+            :color: primary
+            :click-parent:
+            :expand:
+
+            Changelog

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,7 +22,7 @@ that follow these design patterns.
 From here, you can navigate to:
 
 .. grid:: 1 2 2 2
-    :gutter: 2
+    :gutter: 3
 
     .. grid-item-card::
         :text-align: center

--- a/docs/source/user_documentation/user_guide.rst
+++ b/docs/source/user_documentation/user_guide.rst
@@ -31,75 +31,90 @@ that ``skbase`` provides, see the :ref:`api_ref`.
    user_guide/testing
 
 
-.. panels::
-    :card: + intro-card text-center
+.. grid:: 1 2 2 2
+    :gutter: 2
 
-    ---
+    .. grid-item-card::
+        :text-align: center
 
-    Overview
-    ^^^^^^^^
+        Overview
+        ^^^^^^^^
 
-    Get an overview of ``skbase``'s interfaces and design patterns.
+        Get an overview of ``skbase``'s interfaces and design patterns.
 
-    +++
+        +++
 
-    .. link-button:: user_guide/overview
-            :type: ref
-            :text: Overview
-            :classes: btn-block btn-secondary stretched-link
+        .. button-ref:: user_guide/overview
+            :color: primary
+            :click-parent:
+            :expand:
 
-    ---
+            Overview
 
-    Base Classes
-    ^^^^^^^^^^^^
+    .. grid-item-card::
+        :text-align: center
 
-    The skbase class interface.
+        Base Classes
+        ^^^^^^^^^^^^
 
-    +++
+        The skbase class interface.
 
-    .. link-button:: user_guide/base_classes
-            :type: ref
-            :text: Class Interface
-            :classes: btn-block btn-secondary stretched-link
+        +++
 
-    ---
+        .. button-ref:: user_guide/base_classes
+            :color: primary
+            :click-parent:
+            :expand:
 
-    Retrieval
-    ^^^^^^^^^
+            Class Interface
 
-    Tools for collecting ``BaseObject``-s, and metadata on your project.
+    .. grid-item-card::
+        :text-align: center
 
-    +++
+        Retrieval
+        ^^^^^^^^^
 
-    .. link-button:: user_guide/lookup
-            :type: ref
-            :text: Retrieval
-            :classes: btn-block btn-secondary stretched-link
+        Tools for collecting ``BaseObject``-s, and metadata on your project.
 
-    ---
+        +++
 
-    Validation and Comparison
-    ^^^^^^^^^^^^^^^^^^^^^^^^^
+        .. button-ref:: user_guide/lookup
+            :color: primary
+            :click-parent:
+            :expand:
 
-    Tools for validating and comparing ``BaseObject``-s.
+            Retrieval
 
-    +++
+    .. grid-item-card::
+        :text-align: center
 
-    .. link-button:: user_guide/validate
-            :type: ref
-            :text: Validation and Comparison
-            :classes: btn-block btn-secondary stretched-link
+        Validation and Comparison
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    ---
+        Tools for validating and comparing ``BaseObject``-s.
 
-    Testing
-    ^^^^^^^
+        +++
 
-    Tools for testing ``BaseObject``-s.
+        .. button-ref:: user_guide/validate
+            :color: primary
+            :click-parent:
+            :expand:
 
-    +++
+            Validation and Comparison
 
-    .. link-button:: user_guide/testing
-            :type: ref
-            :text: Testing
-            :classes: btn-block btn-secondary stretched-link
+    .. grid-item-card::
+        :text-align: center
+
+        Testing
+        ^^^^^^^
+
+        Tools for testing ``BaseObject``-s.
+
+        +++
+
+        .. button-ref:: user_guide/testing
+            :color: primary
+            :click-parent:
+            :expand:
+
+            Testing

--- a/docs/source/user_documentation/user_guide.rst
+++ b/docs/source/user_documentation/user_guide.rst
@@ -32,7 +32,7 @@ that ``skbase`` provides, see the :ref:`api_ref`.
 
 
 .. grid:: 1 2 2 2
-    :gutter: 2
+    :gutter: 3
 
     .. grid-item-card::
         :text-align: center

--- a/docs/source/user_documentation/user_guide.rst
+++ b/docs/source/user_documentation/user_guide.rst
@@ -34,11 +34,8 @@ that ``skbase`` provides, see the :ref:`api_ref`.
 .. grid:: 1 2 2 2
     :gutter: 3
 
-    .. grid-item-card::
+    .. grid-item-card:: Overview
         :text-align: center
-
-        Overview
-        ^^^^^^^^
 
         Get an overview of ``skbase``'s interfaces and design patterns.
 
@@ -51,11 +48,8 @@ that ``skbase`` provides, see the :ref:`api_ref`.
 
             Overview
 
-    .. grid-item-card::
+    .. grid-item-card:: Base Classes
         :text-align: center
-
-        Base Classes
-        ^^^^^^^^^^^^
 
         The skbase class interface.
 
@@ -68,11 +62,8 @@ that ``skbase`` provides, see the :ref:`api_ref`.
 
             Class Interface
 
-    .. grid-item-card::
+    .. grid-item-card:: Retrieval
         :text-align: center
-
-        Retrieval
-        ^^^^^^^^^
 
         Tools for collecting ``BaseObject``-s, and metadata on your project.
 
@@ -85,11 +76,8 @@ that ``skbase`` provides, see the :ref:`api_ref`.
 
             Retrieval
 
-    .. grid-item-card::
+    .. grid-item-card:: Validation and Comparison
         :text-align: center
-
-        Validation and Comparison
-        ^^^^^^^^^^^^^^^^^^^^^^^^^
 
         Tools for validating and comparing ``BaseObject``-s.
 
@@ -102,11 +90,8 @@ that ``skbase`` provides, see the :ref:`api_ref`.
 
             Validation and Comparison
 
-    .. grid-item-card::
+    .. grid-item-card:: Testing
         :text-align: center
-
-        Testing
-        ^^^^^^^
 
         Tools for testing ``BaseObject``-s.
 

--- a/docs/source/user_documentation/user_guide/validate.rst
+++ b/docs/source/user_documentation/user_guide/validate.rst
@@ -1,0 +1,11 @@
+.. _user_guide_validate:
+
+=========================================
+Validating and Comparing ``BaseObject``-s
+=========================================
+
+.. note::
+
+    The user guide is under development. We have created a basic
+    structure and are looking for contributions to develop the user guide
+    further.

--- a/docs/source/users.rst
+++ b/docs/source/users.rst
@@ -17,7 +17,7 @@ Documentation
 
 
 .. grid:: 1 2 2 2
-    :gutter: 2
+    :gutter: 3
 
     .. grid-item-card::
         :text-align: center

--- a/docs/source/users.rst
+++ b/docs/source/users.rst
@@ -19,11 +19,8 @@ Documentation
 .. grid:: 1 2 2 2
     :gutter: 3
 
-    .. grid-item-card::
+    .. grid-item-card:: Installation
         :text-align: center
-
-        Installation
-        ^^^^^^^^^^^^
 
         Install ``skbase``.
 
@@ -36,11 +33,8 @@ Documentation
 
             Installation
 
-    .. grid-item-card::
+    .. grid-item-card:: Tutorials
         :text-align: center
-
-        Tutorials
-        ^^^^^^^^^
 
         Introductory Tutorials.
 
@@ -53,11 +47,8 @@ Documentation
 
             Tutorials
 
-    .. grid-item-card::
+    .. grid-item-card:: User Guide
         :text-align: center
-
-        User Guide
-        ^^^^^^^^^^
 
         Learn about using ``skbase``.
 
@@ -70,11 +61,8 @@ Documentation
 
             User Guide
 
-    .. grid-item-card::
+    .. grid-item-card:: Glossary
         :text-align: center
-
-        Glossary
-        ^^^^^^^^
 
         Understand common terminology.
 
@@ -87,11 +75,8 @@ Documentation
 
             Glossary
 
-    .. grid-item-card::
+    .. grid-item-card:: Changelog
         :text-align: center
-
-        Changelog
-        ^^^^^^^^^
 
         Information for developers.
 
@@ -104,11 +89,8 @@ Documentation
 
             Changelog
 
-    .. grid-item-card::
+    .. grid-item-card:: Related Software
         :text-align: center
-
-        Related Software
-        ^^^^^^^^^^^^^^^^
 
         Explore software related to ``skbase``.
 

--- a/docs/source/users.rst
+++ b/docs/source/users.rst
@@ -16,89 +16,107 @@ Documentation
    user_documentation/related_software
 
 
-.. panels::
-    :card: + intro-card text-center
+.. grid:: 1 2 2 2
+    :gutter: 2
 
-    ---
+    .. grid-item-card::
+        :text-align: center
 
-    Installation
-    ^^^^^^^^^^^^
+        Installation
+        ^^^^^^^^^^^^
 
-    Install ``skbase``.
+        Install ``skbase``.
 
-    +++
+        +++
 
-    .. link-button:: user_documentation/installation
-            :type: ref
-            :text: Installation
-            :classes: btn-block btn-secondary stretched-link
+        .. button-ref:: user_documentation/installation
+            :color: primary
+            :click-parent:
+            :expand:
 
-    ---
+            Installation
 
-    Tutorials
-    ^^^^^^^^^
+    .. grid-item-card::
+        :text-align: center
 
-    Introductory Tutorials.
+        Tutorials
+        ^^^^^^^^^
 
-    +++
+        Introductory Tutorials.
 
-    .. link-button:: user_documentation/tutorials
-            :type: ref
-            :text: Tutorials
-            :classes: btn-block btn-secondary stretched-link
+        +++
 
-    ---
+        .. button-ref:: user_documentation/tutorials
+            :color: primary
+            :click-parent:
+            :expand:
 
-    User Guide
-    ^^^^^^^^^^
+            Tutorials
 
-    Learn about using ``skbase``.
+    .. grid-item-card::
+        :text-align: center
 
-    +++
+        User Guide
+        ^^^^^^^^^^
 
-    .. link-button:: user_documentation/user_guide
-            :type: ref
-            :text: User Guide
-            :classes: btn-block btn-secondary stretched-link
+        Learn about using ``skbase``.
 
-    ---
+        +++
 
-    Glossary
-    ^^^^^^^^
+        .. button-ref:: user_documentation/user_guide
+            :color: primary
+            :click-parent:
+            :expand:
 
-    Understand common terminology.
+            User Guide
 
-    +++
+    .. grid-item-card::
+        :text-align: center
 
-    .. link-button:: user_documentation/glossary
-            :type: ref
-            :text: Glossary
-            :classes: btn-block btn-secondary stretched-link
+        Glossary
+        ^^^^^^^^
 
-    ---
+        Understand common terminology.
 
-    Changelog
-    ^^^^^^^^^
+        +++
 
-    Information for developers.
+        .. button-ref:: user_documentation/glossary
+            :color: primary
+            :click-parent:
+            :expand:
 
-    +++
+            Glossary
 
-    .. link-button:: user_documentation/changelog
-            :type: ref
-            :text: Developers
-            :classes: btn-block btn-secondary stretched-link
+    .. grid-item-card::
+        :text-align: center
 
-    ---
+        Changelog
+        ^^^^^^^^^
 
-    Related Software
-    ^^^^^^^^^^^^^^^^
+        Information for developers.
 
-    Explore software related to ``skbase``.
+        +++
 
-    +++
+        .. button-ref:: user_documentation/changelog
+            :color: primary
+            :click-parent:
+            :expand:
 
-    .. link-button:: user_documentation/related_software
-            :type: ref
-            :text: Learn More
-            :classes: btn-block btn-secondary stretched-link
+            Changelog
+
+    .. grid-item-card::
+        :text-align: center
+
+        Related Software
+        ^^^^^^^^^^^^^^^^
+
+        Explore software related to ``skbase``.
+
+        +++
+
+        .. button-ref:: user_documentation/related_software
+            :color: primary
+            :click-parent:
+            :expand:
+
+            Related Software

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ docs = [
     "sphinx-issues",
     "sphinx-gallery",
     "sphinx-panels",
+    "sphinx-design",
     "sphinx",
 ]
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #50

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
Uses sphinx-design instead of sphinx-panel in the project's Sphinx docs. Sphinx-design provides a nicer design aesthetic and I believe sphinx-panel is no longer maintained.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->
sphinx-design is a new documentatino dependency (instead of sphinx-panel).

#### What should a reviewer concentrate their feedback on?
Do the affected documentation pages render correctly and are the panels "clickable".