### PR TITLE
Remove deprecation

### DIFF
--- a/skbase/__init__.py
+++ b/skbase/__init__.py
@@ -6,37 +6,9 @@
 The included functionality makes it easy to re-use scikit-learn and
 sktime design principles in your project.
 """
-import warnings
 from typing import List
-
-from skbase.base import BaseEstimator, BaseMetaEstimator, BaseObject
-from skbase.base._meta import _HeterogenousMetaEstimator
-from skbase.lookup import all_objects, get_package_metadata
 
 __version__: str = "0.2.0"
 
 __author__: List[str] = ["mloning", "RNKuhns", "fkiraly"]
-__all__: List[str] = [
-    "BaseObject",
-    "BaseEstimator",
-    "BaseMetaEstimator",
-    "_HeterogenousMetaEstimator",
-    "all_objects",
-    "get_package_metadata",
-]
-
-warnings.warn(
-    " ".join(
-        [
-            "Importing from the `skbase` module is deprecated as of version 0.3.0.",
-            "Ability to import from `skbase` will be removed in version 0.5.0.",
-            "Import BaseObject, BaseEstimator, and HeterogenousMetaEstimator",
-            "from skbase.base. Import lookup functionality ",
-            "(all_objects, get_package_metadata) from skbase.lookup.",
-            "_HeterogenousMetaEstimator has been depracated as of version 0.3.0.",
-            "Functionality is available as part of BaseMetaEstimator.",
-            "_HeterogenousMetaEstimator will be removed in version 0.5.0.",
-        ]
-    ),
-    DeprecationWarning,
-)
+__all__: List[str] = []

--- a/skbase/base/_meta.py
+++ b/skbase/base/_meta.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
 # copyright: skbase developers, BSD-3-Clause License (see LICENSE file)
-# _HeterogenousMetaEstimator re-use code developed in scikit-learn. These elements
-# are copyrighted by the scikit-learn developers, BSD-3-Clause License. For
-# conditions see https://github.com/scikit-learn/scikit-learn/blob/main/COPYING
+# BaseMetaEstimator re-uses code developed in scikit-learn and sktime. These elements
+# are copyrighted by the respective scikit-learn developers (BSD-3-Clause License)
+# and sktime (BSD-3-Clause) developers. For conditions see licensing.
+#  scikit-learn: https://github.com/scikit-learn/scikit-learn/blob/main/COPYING
+# and sktime:  https://github.com/sktime/sktime/blob/main/LICENSE
 """Implements meta estimator for estimators composed of other estimators."""
-import warnings
 from inspect import isclass
 from typing import List
 
@@ -588,23 +589,3 @@ class BaseMetaEstimator(BaseEstimator):
             self.set_tags(**{mid_tag_name: mid_tag_val})
         else:
             self.set_tags(**{mid_tag_name: mid_tag_val_not})
-
-
-class _HeterogenousMetaEstimator(BaseMetaEstimator):
-    """Handles parameter management for estimators composed of named estimators.
-
-    Partly adapted from sklearn utils.metaestimator.py.
-    """
-
-    def __init__(self):
-        super().__init__()
-        warnings.warn(
-            " ".join(
-                [
-                    "_HeterogenousMetaEstimator has been depracated. Functionality is",
-                    "available as part of BaseMetaEstimator.",
-                    "_HeterogenousMetaEstimator will be removed in version 0.5.0.",
-                ]
-            ),
-            DeprecationWarning,
-        )

--- a/skbase/tests/conftest.py
+++ b/skbase/tests/conftest.py
@@ -80,9 +80,7 @@ SKBASE_PUBLIC_CLASSES_BY_MODULE = {
     ),
 }
 SKBASE_CLASSES_BY_MODULE = SKBASE_PUBLIC_CLASSES_BY_MODULE.copy()
-SKBASE_CLASSES_BY_MODULE.update(
-    {"skbase.base._meta": ("BaseMetaEstimator", "_HeterogenousMetaEstimator")}
-)
+SKBASE_CLASSES_BY_MODULE.update({"skbase.base._meta": ("BaseMetaEstimator",)})
 SKBASE_PUBLIC_FUNCTIONS_BY_MODULE = {
     "skbase.lookup": ("all_objects", "get_package_metadata"),
     "skbase.lookup._lookup": ("all_objects", "get_package_metadata"),

--- a/skbase/tests/conftest.py
+++ b/skbase/tests/conftest.py
@@ -67,7 +67,6 @@ SKBASE_PUBLIC_MODULES = (
     "skbase.validate",
 )
 SKBASE_PUBLIC_CLASSES_BY_MODULE = {
-    "skbase": ("BaseEstimator", "BaseMetaEstimator", "BaseObject"),
     "skbase._exceptions": ("FixtureGenerationError", "NotFittedError"),
     "skbase.base": ("BaseEstimator", "BaseMetaEstimator", "BaseObject"),
     "skbase.base._base": ("BaseEstimator", "BaseObject"),
@@ -82,18 +81,9 @@ SKBASE_PUBLIC_CLASSES_BY_MODULE = {
 }
 SKBASE_CLASSES_BY_MODULE = SKBASE_PUBLIC_CLASSES_BY_MODULE.copy()
 SKBASE_CLASSES_BY_MODULE.update(
-    {
-        "skbase": (
-            "BaseEstimator",
-            "BaseMetaEstimator",
-            "BaseObject",
-            "_HeterogenousMetaEstimator",
-        ),
-        "skbase.base._meta": ("BaseMetaEstimator", "_HeterogenousMetaEstimator"),
-    }
+    {"skbase.base._meta": ("BaseMetaEstimator", "_HeterogenousMetaEstimator")}
 )
 SKBASE_PUBLIC_FUNCTIONS_BY_MODULE = {
-    "skbase": ("all_objects", "get_package_metadata"),
     "skbase.lookup": ("all_objects", "get_package_metadata"),
     "skbase.lookup._lookup": ("all_objects", "get_package_metadata"),
     "skbase.testing.utils._conditional_fixtures": (


### PR DESCRIPTION
This removes deprecation added in prior PR refactoring the package to `skbase.base`, `skbase.looup`, `skbase.validate` and `skbase.testing` modules.

The package will use deprecation in the future (likely within the next few releases), but this early in the development is not going to.