### PR TITLE
Update pydocstyle in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
     rev: 6.2.3
     hooks:
       - id: pydocstyle
-        additional_dependencies: ["toml"]
+        additional_dependencies: ["tomli"]
 
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.6.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
           ]
 
   - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.2.3
+    rev: 6.2.2
     hooks:
       - id: pydocstyle
         additional_dependencies: [".[toml]"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
     rev: 6.2.3
     hooks:
       - id: pydocstyle
-        additional_dependencies: ["tomli"]
+        additional_dependencies: [".[toml]"]
 
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.6.1


### PR DESCRIPTION
#### Reference Issues/PRs
There was a commit in `pydocstyle` v6.2.3 that has since been reverted. Version 6.2.4 has not yet been released, so this reverts back to 6.2.2.

Also updating additional dependency section to make use of extra dependency installation. Note that `pydocstyle` switched to using tomli/tomllib for toml parsing instead of toml. Their "extra" install maps this automatically.