### PR TITLE
[ENH] ensure that `all_objects` always returns (class name/class) pairs

### DIFF
--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -844,9 +844,9 @@ def all_objects(
                 classes = inspect.getmembers(module, inspect.isclass)
                 # Filter classes
                 estimators = [
-                    (name, klass)
-                    for name, klass in classes
-                    if _is_estimator(name, klass)
+                    (klass.__name__, klass)
+                    for _, klass in classes
+                    if _is_estimator(klass.__name__, klass)
                 ]
                 all_estimators.extend(estimators)
             except ModuleNotFoundError as e:


### PR DESCRIPTION
`all_objects` in vanilla form returns a list of `(str, BaseObject)` pairs.

Currently, these pairs do not need to satisfy the condition that for the pair `(name, klass)` it holds that `name` = `klass.__name__`.
An example of this case is when a class is assigned to a variable name other than the class name. In that case `name` is the variable name, not the class name. E.g., doing sth like this

```python
class Test:
    def __init__(self, stuff):
        more_stuff

test2 = Test
```
results in the class `Test` being returned twice, once with name `test2` and once with name `Test`.

This can be quite confusing and violate an interface contract that is not strictly stated as guaranteed, but may be assumed by users of the utility (and, apparently, by the status quo in `sktime` as well as the failing tests in the attempted refactor PR https://github.com/sktime/sktime/pull/3777- e.g., see the line `assert estimator[0] == estimator[1].__name__` in `test_all_estimators_by_scitype`)

I would argue that it should always hold that `name` = `klass.__name__` for the returned pairs for that reason.

The alternative solution to this issue would be to make crystal clear in the docstring what is being guaranteed, and what not, about the name/estimator pairs returned.