### PR TITLE
[ENH] `skbase` native `get_params`

### DIFF
--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -74,6 +74,7 @@ class BaseObject(_BaseEstimator):
     """
 
     def __init__(self):
+        """Construct BaseObject."""
         self._tags_dynamic = {}
         super(BaseObject, self).__init__()
 
@@ -704,6 +705,7 @@ class TagAliaserMixin:
     deprecate_dict = {"old_tag": "0.12.0", "tag_to_remove": "99.99.99"}
 
     def __init__(self):
+        """Construct TagAliaserMixin."""
         super(TagAliaserMixin, self).__init__()
 
     @classmethod

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -244,7 +244,7 @@ class BaseObject(_BaseEstimator):
         params = {key: getattr(self, key) for key in self.get_param_names()}
 
         if deep:
-            for key, value in params:
+            for key, value in params.items():
                 if hasattr(value, "get_params"):
                     deep_items = value.get_params().items()
                     params.update({f"{key}__{k}": val} for k, val in deep_items)

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -249,8 +249,8 @@ class BaseObject(_BaseEstimator):
                 if hasattr(value, "get_params"):
                     deep_items = value.get_params().items()
                     deep_params.update({f"{key}__{k}": val for k, val in deep_items})
+            params.update(deep_params)
 
-        params.update(deep_params)
         return params
 
     def set_params(self, **params):

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -216,6 +216,30 @@ class BaseObject(_BaseEstimator):
         }
         return default_dict
 
+    def get_params(self, deep=True):
+        """
+        Get parameters for this estimator.
+
+        Parameters
+        ----------
+        deep : bool, default=True
+            If True, will return the parameters for this estimator and
+            contained subobjects that are estimators.
+
+        Returns
+        -------
+        params : dict
+            Parameter names mapped to their values.
+        """
+        out = dict()
+        for key in self.get_param_names():
+            value = getattr(self, key)
+            if deep and hasattr(value, "get_params"):
+                deep_items = value.get_params().items()
+                out.update((key + "__" + k, val) for k, val in deep_items)
+            out[key] = value
+        return out
+
     def set_params(self, **params):
         """Set the parameters of this object.
 

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -217,19 +217,28 @@ class BaseObject(_BaseEstimator):
         return default_dict
 
     def get_params(self, deep=True):
-        """
-        Get parameters for this estimator.
+        """Get a dict of parameters values for this object.
 
         Parameters
         ----------
         deep : bool, default=True
-            If True, will return the parameters for this estimator and
-            contained subobjects that are estimators.
+            If True, will return a dict of parameter name : value for this object,
+            including parameters of components (= BaseObject-valued parameters).
+            If False, will return a dict of parameter name : value for this object,
+            but not include parameters components.
 
         Returns
         -------
-        params : dict
-            Parameter names mapped to their values.
+        params : dict with str-valued keys
+            keys include:
+            * always: all parameters of this object, as via `get_param_names`
+              values are parameter value for that key, of this object
+              values are always identical to values passed at construction
+            * if `deep=True`, also contains keys/value pairs of component parameters
+              parameters of components are indexed as `[componentname]__[paramname]`
+              all parameters of `componentname` appear as `paramname` with its value
+            * if `deep=True`, also contains arbitrary levels of component recursion,
+              e.g., `[componentname]__[componentcomponentname]__[paramname]`, etc
         """
         out = dict()
         for key in self.get_param_names():

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -240,14 +240,15 @@ class BaseObject(_BaseEstimator):
             * if `deep=True`, also contains arbitrary levels of component recursion,
               e.g., `[componentname]__[componentcomponentname]__[paramname]`, etc
         """
-        out = dict()
-        for key in self.get_param_names():
-            value = getattr(self, key)
-            if deep and hasattr(value, "get_params"):
-                deep_items = value.get_params().items()
-                out.update((key + "__" + k, val) for k, val in deep_items)
-            out[key] = value
-        return out
+        params = {key: getattr(self, key) for key in self.get_param_names()}
+
+        if deep:
+            for key, value in params:
+                if hasattr(value, "get_params"):
+                    deep_items = value.get_params().items()
+                    params.update({f"{key}__{k}": val} for k, val in deep_items)
+
+        return params
 
     def set_params(self, **params):
         """Set the parameters of this object.

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -226,12 +226,13 @@ class BaseObject(_BaseEstimator):
             If True, will return a dict of parameter name : value for this object,
             including parameters of components (= BaseObject-valued parameters).
             If False, will return a dict of parameter name : value for this object,
-            but not include parameters components.
+            but not include parameters of components.
 
         Returns
         -------
         params : dict with str-valued keys
             keys-value pairs include:
+
             * always: all parameters of this object, as via `get_param_names`
               values are parameter value for that key, of this object
               values are always identical to values passed at construction

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -247,7 +247,7 @@ class BaseObject(_BaseEstimator):
             for key, value in params.items():
                 if hasattr(value, "get_params"):
                     deep_items = value.get_params().items()
-                    params.update({f"{key}__{k}": val} for k, val in deep_items)
+                    params.update({f"{key}__{k}": val for k, val in deep_items})
 
         return params
 

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -244,11 +244,13 @@ class BaseObject(_BaseEstimator):
         params = {key: getattr(self, key) for key in self.get_param_names()}
 
         if deep:
+            deep_params = {}
             for key, value in params.items():
                 if hasattr(value, "get_params"):
                     deep_items = value.get_params().items()
-                    params.update({f"{key}__{k}": val for k, val in deep_items})
+                    deep_params.update({f"{key}__{k}": val for k, val in deep_items})
 
+        params.update(deep_params)
         return params
 
     def set_params(self, **params):

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -230,7 +230,7 @@ class BaseObject(_BaseEstimator):
         Returns
         -------
         params : dict with str-valued keys
-            keys include:
+            keys-value pairs include:
             * always: all parameters of this object, as via `get_param_names`
               values are parameter value for that key, of this object
               values are always identical to values passed at construction


### PR DESCRIPTION
Adds an `skbase` native `get_params` to `BaseObject` which replaces the `sklearn` based one. Fixes #116.

The new `get_params` is largely based on the `sklearn` one, with minor changes (better docstring, dependency on `skbase` methods).
As far as I can see, this removes the last logical dependency on `sklearn` `BaseEstimator`.
Credit should already be given through the blanket reference to `sklearn` `BaseEstimator`.

Pretty printing and pretty display still constitute `sklearn` dependencies of `BaseObject`.