### PR TITLE
[MNT] Handle updates to pre-commit linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
     rev: 6.2.3
     hooks:
       - id: pydocstyle
-        additional_dependencies: ["toml"]
+        additional_dependencies: ["tomli"]
 
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.6.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,4 +14,5 @@ max-line-length = 88
 inline-quotes = double
 # See https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html
 extend-ignore = E203
+extend-select = B903, B904, B907
 exclude = .git, __pycache__, docs/source/conf.py, build, dist

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,5 +14,5 @@ max-line-length = 88
 inline-quotes = double
 # See https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html
 extend-ignore = E203
-extend-select = B903, B904, B907
+extend-select = B904, B907
 exclude = .git, __pycache__, docs/source/conf.py, build, dist

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -819,10 +819,10 @@ class TagAliaserMixin:
                 msg = f"tag {tag_name!r} will be removed in sktime version {version}"
                 if new_tag != "":
                     msg += (
-                        f' and replaced by {new_tag!r}, please use "{new_tag}" instead'
+                        f" and replaced by {new_tag!r}, please use {new_tag!r} instead"
                     )
                 else:
-                    msg += ', please remove code that access or sets "{tag_name}"'
+                    msg += ", please remove code that access or sets {tag_name!r}"
                 warnings.warn(msg, category=DeprecationWarning)
 
 

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -816,10 +816,10 @@ class TagAliaserMixin:
             if tag_name in cls.alias_dict.keys():
                 version = cls.deprecate_dict[tag_name]
                 new_tag = cls.alias_dict[tag_name]
-                msg = f'tag "{tag_name}" will be removed in sktime version {version}'
+                msg = f"tag {tag_name!r} will be removed in sktime version {version}"
                 if new_tag != "":
                     msg += (
-                        f' and replaced by "{new_tag}", please use "{new_tag}" instead'
+                        f' and replaced by {new_tag!r}, please use "{new_tag}" instead'
                     )
                 else:
                     msg += ', please remove code that access or sets "{tag_name}"'

--- a/skbase/base/_meta.py
+++ b/skbase/base/_meta.py
@@ -161,15 +161,15 @@ class BaseMetaEstimator(BaseEstimator):
         TypeError, if estimators in the list are not instances of cls_type
         """
         msg = (
-            f"Invalid '{attr_name}' attribute, '{attr_name}' should be a list"
+            f"Invalid {attr_name!r} attribute, {attr_name!r} should be a list"
             " of estimators, or a list of (string, estimator) tuples. "
         )
         if cls_type is None:
-            msg += f"All estimators in '{attr_name}' must be of type BaseEstimator."
+            msg += f"All estimators in {attr_name!r} must be of type BaseEstimator."
             cls_type = BaseEstimator
         elif isclass(cls_type) or isinstance(cls_type, tuple):
             msg += (
-                f"All estimators in '{attr_name}' must be of type "
+                f"All estimators in {attr_name!r} must be of type "
                 f"{cls_type.__name__}."
             )
         else:
@@ -390,7 +390,7 @@ class BaseMetaEstimator(BaseEstimator):
         if concat_order not in ["left", "right"]:
             raise ValueError(
                 f'concat_order must be one of "left", "right", but found '
-                f'"{concat_order}"'
+                f"{concat_order!r}"
             )
         if not isinstance(attr_name, str):
             raise TypeError(f"attr_name must be str, but found {type(attr_name)}")

--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -382,11 +382,11 @@ def _determine_module_path(
             try:
                 loader = _instantiate_loader(package_name, path_)
                 module = _import_module(loader, suppress_import_stdout=False)
-            except ImportError:
+            except ImportError as exc:
                 raise ValueError(
                     f"Unable to import a package named {package_name} based "
                     f"on provided `path`: {path_}."
-                )
+                ) from exc
         else:
             raise ValueError(
                 f"`path` must be a str path or pathlib.Path, but is type {type(path)}."

--- a/skbase/testing/utils/_dependencies.py
+++ b/skbase/testing/utils/_dependencies.py
@@ -96,9 +96,9 @@ def _check_soft_dependencies(
             msg_version = (
                 f"wrong format for package requirement string, "
                 f'must be PEP 440 compatible requirement string, e.g., "pandas"'
-                f' or "pandas>1.1", but found "{package}"'
+                f' or "pandas>1.1", but found {package!r}'
             )
-            raise InvalidRequirement(msg_version)
+            raise InvalidRequirement(msg_version) from None
 
         package_name = req.name
         package_version_req = req.specifier
@@ -121,12 +121,12 @@ def _check_soft_dependencies(
         except ModuleNotFoundError as e:
             msg = (
                 f"{e}. "
-                f"{class_name} requires package '{package}' to be present "
-                f"in the python environment, but '{package}' was not found. "
+                f"{class_name} requires package {package!r} to be present "
+                f"in the python environment, but {package!r} was not found. "
             )
             if obj is not None:
                 msg = msg + (
-                    f"'{package}' is a dependency of {class_name} and required "
+                    f"{package!r} is a dependency of {class_name} and required "
                     f"to construct it. "
                 )
             msg = msg + (
@@ -145,21 +145,21 @@ def _check_soft_dependencies(
                 raise RuntimeError(
                     "Error in calling _check_soft_dependencies, severity "
                     'argument must be "error", "warning", or "none",'
-                    f'found "{severity}".'
-                )
+                    f"found {severity!r}."
+                ) from e
 
         # now we check compatibility with the version specifier if non-empty
         if package_version_req != SpecifierSet(""):
             pkg_env_version = pkg_ref.__version__
 
             msg = (
-                f"{class_name} requires package '{package}' to be present "
+                f"{class_name} requires package {package!r} to be present "
                 f"in the python environment, with version {package_version_req}, "
                 f"but incompatible version {pkg_env_version} was found. "
             )
             if obj is not None:
                 msg = msg + (
-                    f"'{package}', with version {package_version_req},"
+                    f"{package!r}, with version {package_version_req},"
                     f"is a dependency of {class_name} and required to construct it. "
                 )
 
@@ -174,7 +174,7 @@ def _check_soft_dependencies(
                 else:
                     raise RuntimeError(
                         "Error in calling _check_soft_dependencies, severity argument"
-                        f' must be "error", "warning", or "none", found "{severity}".'
+                        f' must be "error", "warning", or "none", found {severity!r}.'
                     )
 
     # if package can be imported and no version issue was caught for any string,
@@ -218,9 +218,9 @@ def _check_python_version(obj, package=None, msg=None, severity="error"):
         msg_version = (
             f"wrong format for python_version tag, "
             f'must be PEP 440 compatible specifier string, e.g., "<3.9, >= 3.6.3",'
-            f' but found "{est_specifier_tag}"'
+            f" but found {est_specifier_tag!r}"
         )
-        raise InvalidSpecifier(msg_version)
+        raise InvalidSpecifier(msg_version) from None
 
     # python sys version, e.g., "3.8.12"
     sys_version = sys.version.split(" ")[0]
@@ -249,6 +249,6 @@ def _check_python_version(obj, package=None, msg=None, severity="error"):
     else:
         raise RuntimeError(
             "Error in calling _check_python_version, severity "
-            f'argument must be "error", "warning", or "none", found "{severity}".'
+            f'argument must be "error", "warning", or "none", found {severity!r}.'
         )
     return True

--- a/skbase/testing/utils/deep_equals.py
+++ b/skbase/testing/utils/deep_equals.py
@@ -175,7 +175,7 @@ def _pandas_equals(x, y, return_msg=False):
             for c in x.columns:
                 is_equal, msg = deep_equals(x[c], y[c], return_msg=True)
                 if not is_equal:
-                    return ret(False, f'["{c}"]' + msg)
+                    return ret(False, f"[{c!r}]" + msg)
             return ret(True, "")
         else:
             return ret(x.equals(y), f".df_equals, x = {x} != y = {y}")


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skbase.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
Fixes error in #119.


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented. Remember to implement
unit tests and docstrings if your pull request commits code to the repository.
-->
There were changes in a few of the linters used in `skbase`'s continuous integration process.

- `pydocstyle` moved to the use of `tomli` or `tomllib` for parsing pyproject.toml files (we are going to use `tomli` since `tomllib` is not available in older Python versions)
- `flake8-bugbear` validation B028 was catching cases of manual quotes in string formatting. It caused #119 to fail. `flake8-bugbear` has since moved this to an optional validation. This enables that validation, along with two others. And fixes the resulting items flagged by the CI.

  - Note that B028 was changed to B907. And optional validations B03 and B904 were also turned on.  `flake8-bugbear` [readme](https://github.com/PyCQA/flake8-bugbear) has a description. This PR includes fixes issues identified by B904.
