### PR TITLE
[MNT] numpy as a soft dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-all_extras = ["pandas"]
+all_extras = ["numpy", "pandas"]
 
 dev = [
     "pre-commit",


### PR DESCRIPTION
This PR adds `numpy` as a soft dependency, see discussion in https://github.com/sktime/skbase/pull/111.

It should be noted that this will have an effect only once the `sklearn` dependency is removed or moved to be a soft dependency, as `numpy` is a core dependency of `sklearn`.