### PR TITLE
[BUG] Fix type error bug

### DIFF
--- a/skbase/tests/conftest.py
+++ b/skbase/tests/conftest.py
@@ -144,7 +144,11 @@ SKBASE_FUNCTIONS_BY_MODULE.update(
             "_coerce_list",
         ),
         "skbase.testing.utils.inspect": ("_get_args",),
-        "skbase.utils._iter": ("_format_seq_to_str", "_scalar_to_seq"),
+        "skbase.utils._iter": (
+            "_format_seq_to_str",
+            "_remove_type_text",
+            "_scalar_to_seq",
+        ),
         "skbase.utils._nested_iter": (
             "_remove_single",
             "flatten",

--- a/skbase/utils/_iter.py
+++ b/skbase/utils/_iter.py
@@ -9,7 +9,11 @@ from typing import Any, List, Optional, Union
 from skbase.utils._nested_iter import _remove_single
 
 __author__: List[str] = ["RNKuhns"]
-__all__: List[str] = []
+__all__: List[str] = [
+    "_scalar_to_seq",
+    "_remove_type_text",
+    "_format_seq_to_str",
+]
 
 
 def _scalar_to_seq(scalar: Any, sequence_type: type = None) -> Sequence:
@@ -61,6 +65,18 @@ def _scalar_to_seq(scalar: Any, sequence_type: type = None) -> Sequence:
         raise ValueError(
             "`sequence_type` must be a subclass of collections.abc.Sequence."
         )
+
+
+def _remove_type_text(input_):
+    """Remove <class > wrapper from printed type str."""
+    if not isinstance(input_, str):
+        input_ = str(input_)
+
+    m = re.match("^<class '(.*)'>$", input_)
+    if m:
+        return m[1]
+    else:
+        return input_
 
 
 def _format_seq_to_str(
@@ -115,14 +131,11 @@ def _format_seq_to_str(
     elif isinstance(seq, (int, float, bool)):
         return str(seq)
     elif not isinstance(seq, Sequence):
-        raise ValueError("`seq` must be a sequence or scalar str, int, float or bool.")
+        raise TypeError("`seq` must be a sequence or scalar str, int, float or bool.")
 
     seq_str = [str(e) for e in seq]
     if remove_type_text:
-        for idx, s in enumerate(seq_str):
-            m = re.match("^<class '(.*)'>$", s)
-            if m:
-                seq_str[idx] = m[1]
+        seq_str = [_remove_type_text(s) for s in seq_str]
 
     if last_sep is None:
         output_str = sep.join(seq_str)

--- a/skbase/utils/tests/test_iter.py
+++ b/skbase/utils/tests/test_iter.py
@@ -71,12 +71,12 @@ def test_format_seq_to_str():
 def test_format_seq_to_str_raises():
     """Test _format_seq_to_str raises error when input is unexpected type."""
     with pytest.raises(
-        ValueError, match="`seq` must be a sequence or scalar str, int, float or bool."
+        TypeError, match="`seq` must be a sequence or scalar str, int, float or bool."
     ):
         _format_seq_to_str((c for c in [1, 2, 3]))
 
     with pytest.raises(
-        ValueError, match="`seq` must be a sequence or scalar str, int, float or bool."
+        TypeError, match="`seq` must be a sequence or scalar str, int, float or bool."
     ):
         _format_seq_to_str(object)
 

--- a/skbase/validate/_types.py
+++ b/skbase/validate/_types.py
@@ -6,7 +6,7 @@ import collections
 import inspect
 from typing import Any, List, Optional, Sequence, Tuple, Union
 
-from skbase.utils._iter import _format_seq_to_str, _scalar_to_seq
+from skbase.utils._iter import _format_seq_to_str, _remove_type_text, _scalar_to_seq
 
 __author__: List[str] = ["RNKuhns", "fkiraly"]
 __all__: List[str] = ["check_sequence", "check_type", "is_sequence"]
@@ -76,7 +76,7 @@ def check_type(
         msg = " ".join(
             [
                 "`expected_type` should be type or tuple[type, ...],"
-                f"but found {type(expected_type)}."
+                f"but found {_remove_type_text(expected_type)}."
             ]
         )
         raise TypeError(msg)
@@ -91,9 +91,14 @@ def check_type(
         return input_
     else:
         chk_msg = "subclass type" if use_subclass else "be type"
-        type_msg = f"{expected_type} or None" if allow_none else f"{expected_type}"
+        expected_type_str = _remove_type_text(expected_type)
+        input_type_str = _remove_type_text(type(input_))
+        if allow_none:
+            type_msg = f"{expected_type_str} or None"
+        else:
+            type_msg = f"{expected_type_str}"
         raise TypeError(
-            f"`{input_name}` should {chk_msg} {type_msg}, but found {type(input_name)}."
+            f"`{input_name}` should {chk_msg} {type_msg}, but found {input_type_str}."
         )
 
 
@@ -327,8 +332,10 @@ def check_sequence(
             element_type_ = _convert_scalar_seq_type_input_to_tuple(
                 element_type, input_name="element_type"
             )
-            element_str = _format_seq_to_str(element_type_, last_sep="or")
-            msg = msg + f"Elements of {name_str} expected to have type {element_str}."
+            element_str = _format_seq_to_str(
+                element_type_, last_sep="or", remove_type_text=True
+            )
+            msg = msg[:-1] + f" with elements of type {element_str}."
 
         raise TypeError(msg)
 

--- a/skbase/validate/_types.py
+++ b/skbase/validate/_types.py
@@ -49,7 +49,7 @@ def check_type(
 
     Raises
     ------
-    ValueError
+    TypeError
         If input does match expected type using isinstance by default
         or using issubclass in check if ``use_subclass=True``.
 
@@ -69,7 +69,7 @@ def check_type(
     An error is raised if the input is not the expected type
 
     >>> check_type(7, expected_type=str) # doctest: +SKIP
-    ValueError: `input` should be type <class 'str'>, but found <class 'str'>.
+    TypeError: `input` should be type <class 'str'>, but found <class 'str'>.
     """
     # process expected_type parameter
     if not isinstance(expected_type, (type, tuple)):
@@ -79,7 +79,7 @@ def check_type(
                 f"but found {type(expected_type)}."
             ]
         )
-        raise ValueError(msg)
+        raise TypeError(msg)
 
     # Assign default name to input_name parameter in case it is None
     if input_name is None:
@@ -92,7 +92,7 @@ def check_type(
     else:
         chk_msg = "subclass type" if use_subclass else "be type"
         type_msg = f"{expected_type} or None" if allow_none else f"{expected_type}"
-        raise ValueError(
+        raise TypeError(
             f"`{input_name}` should {chk_msg} {type_msg}, but found {type(input_name)}."
         )
 
@@ -121,7 +121,7 @@ def _convert_scalar_seq_type_input_to_tuple(
         seq_output = (type_input,)
     else:
         name_str = "type_input" if input_name is None else input_name
-        raise ValueError(f"`{name_str}` should be a type or tuple of types.")
+        raise TypeError(f"`{name_str}` should be a type or tuple of types.")
 
     return seq_output
 
@@ -160,12 +160,6 @@ def is_sequence(
     bool
         Whether the input is a valid sequence based on the supplied `sequence_type`
         and `element_type`.
-
-    Raises
-    ------
-    ValueError
-        If input is not a sequence and optionally if the elements of the sequence
-        have types that don't match the `element_type` parameter value.
 
     Examples
     --------
@@ -263,7 +257,7 @@ def check_sequence(
 
     Raises
     ------
-    ValueError :
+    TypeError :
         If `seq` is not instance of `sequence_type` or ``element_type is not None`` and
         all elements are not instances of `element_type`.
 
@@ -336,7 +330,7 @@ def check_sequence(
             element_str = _format_seq_to_str(element_type_, last_sep="or")
             msg = msg + f"Elements of {name_str} expected to have type {element_str}."
 
-        raise ValueError(msg)
+        raise TypeError(msg)
 
     if coerce_output_type_to is not None:
         return coerce_output_type_to(input_seq)

--- a/skbase/validate/tests/test_type_validations.py
+++ b/skbase/validate/tests/test_type_validations.py
@@ -63,6 +63,10 @@ def test_check_type_output(fixture_estimator_instance, fixture_object_instance):
 
     with pytest.raises(TypeError, match=r"`input` should be type.*"):
         check_type(BaseEstimator, expected_type=BaseObject)
+
+    with pytest.raises(TypeError, match="^`input` should be.*"):
+        check_type("something", expected_type=int, allow_none=True)
+
     # Verify optional use of issubclass instead of isinstance
     assert (
         check_type(BaseEstimator, expected_type=BaseObject, use_subclass=True)

--- a/skbase/validate/tests/test_type_validations.py
+++ b/skbase/validate/tests/test_type_validations.py
@@ -43,6 +43,7 @@ def test_check_type_output(fixture_estimator_instance, fixture_object_instance):
     assert check_type(7.2, expected_type=float) == 7.2
     assert check_type(7.2, expected_type=(float, int)) == 7.2
     assert check_type("something", expected_type=str) == "something"
+    assert check_type(None, expected_type=str, allow_none=True) is None
     assert check_type(["a", 7, fixture_object_instance], expected_type=list) == [
         "a",
         7,
@@ -79,6 +80,9 @@ def test_check_type_raises_error_if_expected_type_is_wrong_format():
 
     with pytest.raises(TypeError, match="^`expected_type` should be.*"):
         check_type(7, expected_type=[int])
+
+    with pytest.raises(TypeError, match="^`expected_type` should be.*"):
+        check_type(None, expected_type=[int])
 
 
 def test_is_sequence_output():

--- a/skbase/validate/tests/test_type_validations.py
+++ b/skbase/validate/tests/test_type_validations.py
@@ -54,13 +54,13 @@ def test_check_type_output(fixture_estimator_instance, fixture_object_instance):
     )
     assert check_type(None, expected_type=int, allow_none=True) is None
 
-    with pytest.raises(ValueError, match=r"`input` should be type.*"):
+    with pytest.raises(TypeError, match=r"`input` should be type.*"):
         check_type(7.2, expected_type=int)
 
-    with pytest.raises(ValueError, match=r"`input` should be type.*"):
+    with pytest.raises(TypeError, match=r"`input` should be type.*"):
         check_type("something", expected_type=(int, float))
 
-    with pytest.raises(ValueError, match=r"`input` should be type.*"):
+    with pytest.raises(TypeError, match=r"`input` should be type.*"):
         check_type(BaseEstimator, expected_type=BaseObject)
     # Verify optional use of issubclass instead of isinstance
     assert (
@@ -74,10 +74,10 @@ def test_check_type_raises_error_if_expected_type_is_wrong_format():
 
     `expected_type` should be a type or tuple of types.
     """
-    with pytest.raises(ValueError, match="^`expected_type` should be.*"):
+    with pytest.raises(TypeError, match="^`expected_type` should be.*"):
         check_type(7, expected_type=11)
 
-    with pytest.raises(ValueError, match="^`expected_type` should be.*"):
+    with pytest.raises(TypeError, match="^`expected_type` should be.*"):
         check_type(7, expected_type=[int])
 
 
@@ -161,7 +161,7 @@ def test_check_sequence_output():
     assert check_sequence([1, "a", 3.4, False]) == [1, "a", 3.4, False]
     # But false for generators, since they are iterable but not sequences
     with pytest.raises(
-        ValueError,
+        TypeError,
         match="Invalid sequence: Input sequence expected to be a a sequence.",
     ):
         assert check_sequence((c for c in [1, 2, 3]))
@@ -169,12 +169,12 @@ def test_check_sequence_output():
     # Test use of sequence_type restriction
     assert check_sequence([1, 2, 3, 4], sequence_type=list) == [1, 2, 3, 4]
     with pytest.raises(
-        ValueError,
+        TypeError,
         match="Invalid sequence: Input sequence expected to be a tuple.",
     ):
         check_sequence([1, 2, 3, 4], sequence_type=tuple)
     with pytest.raises(
-        ValueError,
+        TypeError,
         match="Invalid sequence: Input sequence expected to be a list.",
     ):
         check_sequence((1, 2, 3, 4), sequence_type=list)
@@ -193,22 +193,22 @@ def test_check_sequence_output():
     ]
 
     with pytest.raises(
-        ValueError,
+        TypeError,
         match="Invalid sequence: .*",
     ):
         check_sequence([1, 2, 3], element_type=float)
     with pytest.raises(
-        ValueError,
+        TypeError,
         match="Invalid sequence: .*",
     ):
         check_sequence([1, 2, 3, 4], sequence_type=tuple, element_type=int)
     with pytest.raises(
-        ValueError,
+        TypeError,
         match="Invalid sequence: .*",
     ):
         check_sequence([1, 2, 3, 4], sequence_type=list, element_type=float)
     with pytest.raises(
-        ValueError,
+        TypeError,
         match="Invalid sequence: .*",
     ):
         check_sequence([1, 2, 3, 4], sequence_type=tuple, element_type=float)
@@ -221,7 +221,7 @@ def test_check_sequence_output():
     assert check_sequence("abc") == "abc"
     assert check_sequence([1, "something", 4.5]) == [1, "something", 4.5]
     with pytest.raises(
-        ValueError,
+        TypeError,
         match="Invalid sequence: .*",
     ):
         check_sequence([1, "something", 4.5], element_type=float)
@@ -232,7 +232,7 @@ def test_check_sequence_output():
 
     # Test with 3rd party types works in default way via exact type
     with pytest.raises(
-        ValueError,
+        TypeError,
         match="Invalid sequence: .*",
     ):
         check_sequence([1.2, 4.7], element_type=np.float_)
@@ -247,7 +247,7 @@ def test_check_sequence_output():
         7,
     ]
     with pytest.raises(
-        ValueError,
+        TypeError,
         match="Invalid sequence: .*",
     ):
         check_sequence([np.nan, 4], element_type=int)
@@ -290,7 +290,7 @@ def test_check_sequence_scalar_input_coercion():
 
     # Still raise an error if element type is not expected
     with pytest.raises(
-        ValueError,
+        TypeError,
         match="Invalid sequence: .*",
     ):
         check_sequence(
@@ -313,12 +313,12 @@ def test_check_sequence_with_seq_of_class_and_instance_input(
     ) == list(input_seq)
 
     with pytest.raises(
-        ValueError,
+        TypeError,
         match="Invalid sequence: .*",
     ):
         check_sequence(list(input_seq), sequence_type=tuple, element_type=BaseObject)
     with pytest.raises(
-        ValueError,
+        TypeError,
         match="Invalid sequence: .*",
     ):
         # Verify we detect when list elements are not instances of valid class type
@@ -331,7 +331,7 @@ def test_check_sequence_with_seq_of_class_and_instance_input(
         list(input_seq), sequence_type=list, element_type=type
     ) == list(input_seq)
     with pytest.raises(
-        ValueError,
+        TypeError,
         match="Invalid sequence: .*",
     ):
         # Verify we detect when list elements are not instances of valid types
@@ -342,19 +342,19 @@ def test_convert_scalar_seq_type_input_to_tuple_raises_error():
     """Test _convert_scalar_seq_type_input_to_tuple raises error."""
     # Raises because 7 is not a type
     with pytest.raises(
-        ValueError, match=r"`type_input` should be a type or tuple of types."
+        TypeError, match=r"`type_input` should be a type or tuple of types."
     ):
         _convert_scalar_seq_type_input_to_tuple(7)
 
     # Test error message uses input_name
     with pytest.raises(
-        ValueError, match=r"`some_input` should be a type or tuple of types."
+        TypeError, match=r"`some_input` should be a type or tuple of types."
     ):
         _convert_scalar_seq_type_input_to_tuple(7, input_name="some_input")
 
     # Raises error because dict is a type but not a subclass of type_input_subclass
     with pytest.raises(
-        ValueError, match=r"`type_input` should be a type or tuple of types."
+        TypeError, match=r"`type_input` should be a type or tuple of types."
     ):
         _convert_scalar_seq_type_input_to_tuple(
             dict,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skbase.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
<!--
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #129. 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented. Remember to implement
unit tests and docstrings if your pull request commits code to the repository.
-->
Error referenced in #129  was being raised through `skbase.utils.check_sequence`. This cleans up the error messaging there and in other type checking utility functions. They now raise `TypeError`s and use a utility function to remove boilerplate "<class >" when converting classes to strings.

#### Does your contribution introduce a new dependency? If yes, which one?
<!--
If your contribution requires a new dependency please indicate why it is necessary.
skbase seeks to mimimize dependencies to make it easy to use skbase in a variety
of environments and contexts.
-->
None.

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development.
You can guide the reviews to focus on the parts that are ready for their comments.
We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
Change in error messages.

#### Any other comments?
<!--
Is there any other information the reviewer should know?
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [X] I've reviewed the project documentation on [contributing](https://skbase.readthedocs.io/en/latest/contribute.html)
- [X] I've added myself to the [list of contributors](https://github.com/sktime/skbase/blob/main/.all-contributorsrc).
- [X] The PR title starts with either [ENH], [CI/CD], [MNT], [DOC], or [BUG] indicating whether
  the PR topic is related to enhancement, CI/CD, maintenance, documentation, or a bug.

##### For code contributions
- [X] Unit tests have been added covering code functionality
- [X] Appropriate docstrings have been added (see [documentation standards](https://skbase.readthedocs.io/en/latest/contribute/development/developer_guide/creating_docs.html))
- [X] New public functionality has been added to the API Reference


<!--
Thanks for contributing!
-->
