### PR TITLE
Add stacklevel to warnings.warn calls

### DIFF
--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -865,7 +865,7 @@ class TagAliaserMixin:
                     )
                 else:
                     msg += ", please remove code that access or sets {tag_name!r}"
-                warnings.warn(msg, category=DeprecationWarning)
+                warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
 
 
 class BaseEstimator(BaseObject):

--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -853,7 +853,7 @@ def all_objects(
                 # Skip missing soft dependencies
                 if "soft dependency" not in str(e):
                     raise e
-                warnings.warn(str(e), ImportWarning)
+                warnings.warn(str(e), ImportWarning, stacklevel=2)
 
     # Drop duplicates
     all_estimators = set(all_estimators)

--- a/skbase/testing/utils/_dependencies.py
+++ b/skbase/testing/utils/_dependencies.py
@@ -136,7 +136,7 @@ def _check_soft_dependencies(
             if severity == "error":
                 raise ModuleNotFoundError(msg) from e
             elif severity == "warning":
-                warnings.warn(msg)
+                warnings.warn(msg, stacklevel=2)
                 return False
             elif severity == "none":
                 return False
@@ -167,7 +167,7 @@ def _check_soft_dependencies(
                 if severity == "error":
                     raise ModuleNotFoundError(msg)
                 elif severity == "warning":
-                    warnings.warn(msg)
+                    warnings.warn(msg, stacklevel=2)
                 elif severity == "none":
                     return False
                 else:
@@ -242,7 +242,7 @@ def _check_python_version(obj, package=None, msg=None, severity="error"):
     if severity == "error":
         raise ModuleNotFoundError(msg)
     elif severity == "warning":
-        warnings.warn(msg)
+        warnings.warn(msg, stacklevel=2)
     elif severity == "none":
         return False
     else:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skbase.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
`flake8` raises a warning for calls to `warnings.warn` that don't specify the `stacklevel` parameter. `stacklevel` controls where the warning is shown from. Using ``stacklevel=2`` raises the warning at the code 1-level above the `warnings.warn` call, which seems like a reasonable default.


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've reviewed the project documentation on [contributing](https://skbase.readthedocs.io/en/latest/contribute.html)
- [x] I've added myself to the [list of contributors](https://github.com/sktime/skbase/blob/main/.all-contributorsrc).
- [x] The PR title starts with either [ENH], [CI/CD], [MNT], [DOC], or [BUG] indicating whether
  the PR topic is related to enhancement, CI/CD, maintenance, documentation, or a bug.

##### For code contributions
- [ ] Unit tests have been added covering code functionality
- [ ] Appropriate docstrings have been added (see [documentation standards](https://skbase.readthedocs.io/en/latest/contribute/development/developer_guide/creating_docs.html))
- [ ] New public functionality has been added to the API Reference


<!--
Thanks for contributing!
-->
