### PR TITLE
[ENH] tag manager mixin

### DIFF
--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -76,7 +76,7 @@ class BaseObject(_FlagManager, _BaseEstimator):
 
     def __init__(self):
         """Construct BaseObject."""
-        self._tags_dynamic = {}
+        self._init_flags(flag_attr_name="_tags")
         super(BaseObject, self).__init__()
 
     def __eq__(self, other):

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -62,12 +62,13 @@ from sklearn import clone
 from sklearn.base import BaseEstimator as _BaseEstimator
 
 from skbase._exceptions import NotFittedError
+from skbase.base._tagmanager import _FlagManager
 
 __author__: List[str] = ["mloning", "RNKuhns", "fkiraly"]
 __all__: List[str] = ["BaseEstimator", "BaseObject"]
 
 
-class BaseObject(_BaseEstimator):
+class BaseObject(_FlagManager, _BaseEstimator):
     """Base class for parametric objects with sktime style tag interface.
 
     Extends scikit-learn's BaseEstimator to include sktime style interface for tags.
@@ -317,19 +318,7 @@ class BaseObject(_BaseEstimator):
             Dictionary of class tag name: tag value pairs. Collected from _tags
             class attribute via nested inheritance.
         """
-        collected_tags = {}
-
-        # We exclude the last two parent classes: sklearn.base.BaseEstimator and
-        # the basic Python object.
-        for parent_class in reversed(inspect.getmro(cls)[:-2]):
-            if hasattr(parent_class, "_tags"):
-                # Need the if here because mixins might not have _more_tags
-                # but might do redundant work in estimators
-                # (i.e. calling more tags on BaseEstimator multiple times)
-                more_tags = parent_class._tags
-                collected_tags.update(more_tags)
-
-        return deepcopy(collected_tags)
+        return cls._get_class_flags(flag_attr_name="_tags")
 
     @classmethod
     def get_class_tag(cls, tag_name, tag_value_default=None):
@@ -351,9 +340,11 @@ class BaseObject(_BaseEstimator):
             Value of the `tag_name` tag in self. If not found, returns
             `tag_value_default`.
         """
-        collected_tags = cls.get_class_tags()
-
-        return collected_tags.get(tag_name, tag_value_default)
+        return cls._get_class_flag(
+            flag_name=tag_name,
+            flag_value_default=tag_value_default,
+            flag_attr_name="_tags",
+        )
 
     def get_tags(self):
         """Get tags from estimator class and dynamic tag overrides.
@@ -365,12 +356,7 @@ class BaseObject(_BaseEstimator):
             class attribute via nested inheritance and then any overrides
             and new tags from _tags_dynamic object attribute.
         """
-        collected_tags = self.get_class_tags()
-
-        if hasattr(self, "_tags_dynamic"):
-            collected_tags.update(self._tags_dynamic)
-
-        return deepcopy(collected_tags)
+        return self._get_flags(flag_attr_name="_tags")
 
     def get_tag(self, tag_name, tag_value_default=None, raise_error=True):
         """Get tag value from estimator class and dynamic tag overrides.
@@ -395,14 +381,12 @@ class BaseObject(_BaseEstimator):
         ValueError if raise_error is True i.e. if `tag_name` is not in
         self.get_tags().keys()
         """
-        collected_tags = self.get_tags()
-
-        tag_value = collected_tags.get(tag_name, tag_value_default)
-
-        if raise_error and tag_name not in collected_tags.keys():
-            raise ValueError(f"Tag with name {tag_name} could not be found.")
-
-        return tag_value
+        return self._get_flag(
+            flag_name=tag_name,
+            flag_value_default=tag_value_default,
+            raise_error=raise_error,
+            flag_attr_name="_tags",
+        )
 
     def set_tags(self, **tag_dict):
         """Set dynamic tags to given values.
@@ -421,11 +405,7 @@ class BaseObject(_BaseEstimator):
         -----
         Changes object state by settting tag values in tag_dict as dynamic tags in self.
         """
-        tag_update = deepcopy(tag_dict)
-        if hasattr(self, "_tags_dynamic"):
-            self._tags_dynamic.update(tag_update)
-        else:
-            self._tags_dynamic = tag_update
+        self._set_flags(flag_attr_name="_tags", **tag_dict)
 
         return self
 
@@ -449,20 +429,9 @@ class BaseObject(_BaseEstimator):
         Changes object state by setting tag values in tag_set from estimator as
         dynamic tags in self.
         """
-        tags_est = deepcopy(estimator.get_tags())
-
-        # if tag_set is not passed, default is all tags in estimator
-        if tag_names is None:
-            tag_names = tags_est.keys()
-        else:
-            # if tag_set is passed, intersect keys with tags in estimator
-            if not isinstance(tag_names, list):
-                tag_names = [tag_names]
-            tag_names = [key for key in tag_names if key in tags_est.keys()]
-
-        update_dict = {key: tags_est[key] for key in tag_names}
-
-        self.set_tags(**update_dict)
+        self._clone_flags(
+            estimator=estimator, flag_names=tag_names, flag_attr_name="_tags"
+        )
 
         return self
 

--- a/skbase/base/_tagmanager.py
+++ b/skbase/base/_tagmanager.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+"""Mixin class for flag and configuration settings management."""
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+
+__author__ = ["fkiraly"]
+__all__ = ["_FlagManager"]
+
+
+import inspect
+from copy import deepcopy
+
+
+class _FlagManager:
+    """Mixin class for flag and configuration settings management."""
+
+    @classmethod
+    def _get_class_flags(cls, flag_attr_name="_flags"):
+        """Get class flags from estimator class and all its parent classes.
+
+        Parameters
+        ----------
+        flag_attr_name : str, optional, default = "_flags"
+            name of the flag attribute that is read
+
+        Returns
+        -------
+        collected_flags : dict
+            Dictionary of flag name : flag value pairs. Collected from _flags
+            class attribute via nested inheritance. NOT overridden by dynamic
+            flags set by set_flags or clone_flags.
+        """
+        collected_flags = dict()
+
+        # We exclude the last two parent classes: sklearn.base.BaseEstimator and
+        # the basic Python object.
+        for parent_class in reversed(inspect.getmro(cls)[:-2]):
+            if hasattr(parent_class, flag_attr_name):
+                # Need the if here because mixins might not have _more_flags
+                # but might do redundant work in estimators
+                # (i.e. calling more flags on BaseEstimator multiple times)
+                more_flags = getattr(parent_class, flag_attr_name)
+                collected_flags.update(more_flags)
+
+        return deepcopy(collected_flags)
+
+    @classmethod
+    def _get_class_flag(
+        cls, flag_name, flag_value_default=None, flag_attr_name="_flags"
+    ):
+        """Get flag value from estimator class (only class flags).
+
+        Parameters
+        ----------
+        flag_name : str
+            Name of flag value.
+        flag_value_default : any type
+            Default/fallback value if flag is not found.
+        flag_attr_name : str, optional, default = "_flags"
+            name of the flag attribute that is read
+
+        Returns
+        -------
+        flag_value :
+            Value of `flag_name` flag in self. If not found, `flag_value_default`.
+        """
+        collected_flags = cls._get_class_flags(flag_attr_name=flag_attr_name)
+
+        return collected_flags.get(flag_name, flag_value_default)
+
+    def _init_flags(self, flag_attr_name="_flags"):
+        """Create dynamic flag dictionary in self.
+
+        Should be called in __init__ of the host class.
+        Creates attribute [flag_attr_name]_dynamic containing an empty dict.
+
+        Parameters
+        ----------
+        flag_attr_name : str, optional, default = "_flags"
+            name of the flag attribute that is read
+
+        Returns
+        -------
+        self : reference to self
+        """
+        setattr(self, f"{flag_attr_name}_dynamic", dict())
+        return self
+
+    def _get_flags(self, flag_attr_name="_flags"):
+        """Get flags from estimator class and dynamic flag overrides.
+
+        Parameters
+        ----------
+        flag_attr_name : str, optional, default = "_flags"
+            name of the flag attribute that is read
+
+        Returns
+        -------
+        collected_flags : dict
+            Dictionary of flag name : flag value pairs. Collected from flag_attr_name
+            class attribute via nested inheritance and then any overrides
+            and new flags from [flag_attr_name]_dynamic object attribute.
+        """
+        collected_flags = self._get_class_flags(flag_attr_name=flag_attr_name)
+
+        if hasattr(self, f"{flag_attr_name}_dynamic"):
+            collected_flags.update(getattr(self, f"{flag_attr_name}_dynamic"))
+
+        return deepcopy(collected_flags)
+
+    def _get_flag(
+        self,
+        flag_name,
+        flag_value_default=None,
+        raise_error=True,
+        flag_attr_name="_flags",
+    ):
+        """Get flag value from estimator class and dynamic flag overrides.
+
+        Parameters
+        ----------
+        flag_name : str
+            Name of flag to be retrieved
+        flag_value_default : any type, optional; default=None
+            Default/fallback value if flag is not found
+        raise_error : bool
+            whether a ValueError is raised when the flag is not found
+        flag_attr_name : str, optional, default = "_flags"
+            name of the flag attribute that is read
+
+        Returns
+        -------
+        flag_value :
+            Value of the `flag_name` flag in self. If not found, returns an error if
+            raise_error is True, otherwise it returns `flag_value_default`.
+
+        Raises
+        ------
+        ValueError if raise_error is True i.e. if flag_name is not in self.get_flags(
+        ).keys()
+        """
+        collected_flags = self._get_flags(flag_attr_name=flag_attr_name)
+
+        flag_value = collected_flags.get(flag_name, flag_value_default)
+
+        if raise_error and flag_name not in collected_flags.keys():
+            raise ValueError(f"Tag with name {flag_name} could not be found.")
+
+        return flag_value
+
+    def _set_flags(self, flag_attr_name="_flags", **flag_dict):
+        """Set dynamic flags to given values.
+
+        Parameters
+        ----------
+        flag_dict : dict
+            Dictionary of flag name : flag value pairs.
+        flag_attr_name : str, optional, default = "_flags"
+            name of the flag attribute that is read
+
+        Returns
+        -------
+        Self : Reference to self.
+
+        Notes
+        -----
+        Changes object state by settting flag values in flag_dict as dynamic flags
+        in self.
+        """
+        flag_update = deepcopy(flag_dict)
+        dynamic_flags = f"{flag_attr_name}_dynamic"
+        if hasattr(self, dynamic_flags):
+            getattr(self, dynamic_flags).update(flag_update)
+        else:
+            setattr(self, dynamic_flags, flag_update)
+
+        return self
+
+    def _clone_flags(self, estimator, flag_names=None, flag_attr_name="_flags"):
+        """clone/mirror flags from another estimator as dynamic override.
+
+        Parameters
+        ----------
+        estimator : estimator inheriting from :class:BaseEstimator
+        flag_names : str or list of str, default = None
+            Names of flags to clone. If None then all flags in estimator are used
+            as `flag_names`.
+        flag_attr_name : str, optional, default = "_flags"
+            name of the flag attribute that is read
+
+        Returns
+        -------
+        Self :
+            Reference to self.
+
+        Notes
+        -----
+        Changes object state by setting flag values in flag_set from estimator as
+        dynamic flags in self.
+        """
+        flags_est = deepcopy(estimator._get_flags(flag_attr_name=flag_attr_name))
+
+        # if flag_set is not passed, default is all flags in estimator
+        if flag_names is None:
+            flag_names = flags_est.keys()
+        else:
+            # if flag_set is passed, intersect keys with flags in estimator
+            if not isinstance(flag_names, list):
+                flag_names = [flag_names]
+            flag_names = [key for key in flag_names if key in flags_est.keys()]
+
+        update_dict = {key: flags_est[key] for key in flag_names}
+
+        self._set_flags(flag_attr_name=flag_attr_name, **update_dict)
+
+        return self

--- a/skbase/base/_tagmanager.py
+++ b/skbase/base/_tagmanager.py
@@ -29,7 +29,7 @@ class _FlagManager:
             class attribute via nested inheritance. NOT overridden by dynamic
             flags set by set_flags or clone_flags.
         """
-        collected_flags = dict()
+        collected_flags = {}
 
         # We exclude the last two parent classes: sklearn.base.BaseEstimator and
         # the basic Python object.
@@ -82,7 +82,7 @@ class _FlagManager:
         -------
         self : reference to self
         """
-        setattr(self, f"{flag_attr_name}_dynamic", dict())
+        setattr(self, f"{flag_attr_name}_dynamic", {})
         return self
 
     def _get_flags(self, flag_attr_name="_flags"):

--- a/skbase/base/_tagmanager.py
+++ b/skbase/base/_tagmanager.py
@@ -60,7 +60,7 @@ class _FlagManager:
 
         Returns
         -------
-        flag_value :
+        flag_value
             Value of `flag_name` flag in self. If not found, `flag_value_default`.
         """
         collected_flags = cls._get_class_flags(flag_attr_name=flag_attr_name)
@@ -135,8 +135,9 @@ class _FlagManager:
 
         Raises
         ------
-        ValueError if raise_error is True i.e. if flag_name is not in self.get_flags(
-        ).keys()
+        ValueError
+            if `raise_error` is `True`, i.e.,
+            if `flag_name` is not in `self.get_flags().keys()`
         """
         collected_flags = self._get_flags(flag_attr_name=flag_attr_name)
 
@@ -159,7 +160,8 @@ class _FlagManager:
 
         Returns
         -------
-        self : Reference to self.
+        self
+            Reference to self.
 
         Notes
         -----
@@ -189,7 +191,7 @@ class _FlagManager:
 
         Returns
         -------
-        self :
+        self
             Reference to self.
 
         Notes

--- a/skbase/base/_tagmanager.py
+++ b/skbase/base/_tagmanager.py
@@ -19,8 +19,8 @@ class _FlagManager:
 
         Parameters
         ----------
-        flag_attr_name : str, optional, default = "_flags"
-            name of the flag attribute that is read
+        flag_attr_name : str, default = "_flags"
+            Name of the flag attribute that is read.
 
         Returns
         -------
@@ -55,8 +55,8 @@ class _FlagManager:
             Name of flag value.
         flag_value_default : any type
             Default/fallback value if flag is not found.
-        flag_attr_name : str, optional, default = "_flags"
-            name of the flag attribute that is read
+        flag_attr_name : str, default = "_flags"
+            Name of the flag attribute that is read.
 
         Returns
         -------
@@ -75,8 +75,8 @@ class _FlagManager:
 
         Parameters
         ----------
-        flag_attr_name : str, optional, default = "_flags"
-            name of the flag attribute that is read
+        flag_attr_name : str, default = "_flags"
+            Name of the flag attribute that is read.
 
         Returns
         -------
@@ -90,8 +90,8 @@ class _FlagManager:
 
         Parameters
         ----------
-        flag_attr_name : str, optional, default = "_flags"
-            name of the flag attribute that is read
+        flag_attr_name : str, default = "_flags"
+            Name of the flag attribute that is read.
 
         Returns
         -------
@@ -119,13 +119,13 @@ class _FlagManager:
         Parameters
         ----------
         flag_name : str
-            Name of flag to be retrieved
-        flag_value_default : any type, optional; default=None
+            Name of flag to be retrieved.
+        flag_value_default : any type, default=None
             Default/fallback value if flag is not found
         raise_error : bool
-            whether a ValueError is raised when the flag is not found
-        flag_attr_name : str, optional, default = "_flags"
-            name of the flag attribute that is read
+            Whether a `ValueError` is raised when the flag is not found.
+        flag_attr_name : str, default = "_flags"
+            Name of the flag attribute that is read.
 
         Returns
         -------
@@ -154,12 +154,12 @@ class _FlagManager:
         ----------
         flag_dict : dict
             Dictionary of flag name : flag value pairs.
-        flag_attr_name : str, optional, default = "_flags"
-            name of the flag attribute that is read
+        flag_attr_name : str, default = "_flags"
+            Name of the flag attribute that is read.
 
         Returns
         -------
-        Self : Reference to self.
+        self : Reference to self.
 
         Notes
         -----
@@ -184,12 +184,12 @@ class _FlagManager:
         flag_names : str or list of str, default = None
             Names of flags to clone. If None then all flags in estimator are used
             as `flag_names`.
-        flag_attr_name : str, optional, default = "_flags"
-            name of the flag attribute that is read
+        flag_attr_name : str, default = "_flags"
+            Name of the flag attribute that is read.
 
         Returns
         -------
-        Self :
+        self :
             Reference to self.
 
         Notes

--- a/skbase/tests/conftest.py
+++ b/skbase/tests/conftest.py
@@ -83,7 +83,12 @@ SKBASE_PUBLIC_CLASSES_BY_MODULE = {
     ),
 }
 SKBASE_CLASSES_BY_MODULE = SKBASE_PUBLIC_CLASSES_BY_MODULE.copy()
-SKBASE_CLASSES_BY_MODULE.update({"skbase.base._meta": ("BaseMetaEstimator",)})
+SKBASE_CLASSES_BY_MODULE.update(
+    {
+        "skbase.base._meta": ("BaseMetaEstimator",),
+        "skbase.base._tagmanager": ("_FlagManager",),
+    }
+)
 SKBASE_PUBLIC_FUNCTIONS_BY_MODULE = {
     "skbase.lookup": ("all_objects", "get_package_metadata"),
     "skbase.lookup._lookup": ("all_objects", "get_package_metadata"),

--- a/skbase/tests/conftest.py
+++ b/skbase/tests/conftest.py
@@ -22,6 +22,7 @@ SKBASE_MODULES = (
     "skbase.base",
     "skbase.base._base",
     "skbase.base._meta",
+    "skbase.base._tagmanager",
     "skbase.lookup",
     "skbase.lookup.tests",
     "skbase.lookup.tests.test_lookup",


### PR DESCRIPTION
port of https://github.com/sktime/sktime/pull/3630 to `skbase`

This PR factors out the tag management logic into a `_FlagManager` mixin, and generalizes the functionality so it can be used for multiple fields of tags.

Advantages:
* increases cohesion and reduces coupling, separates concerns in the `BaseObject` class: state/parameter management and tag management
* prepares the ground for managing configuration fields, e.g., for implementing a `set_config` similar to the new `sklearn` feature

Test coverage is already there for the base case, but should be added for a different tag field. Will do that with the PR that adds config handling.

(I called the flag manager since not all flags are tags, and interactions with the sklearn `_get_tags`)

A STEP is available here: https://github.com/sktime/enhancement-proposals/pull/29