### PR TITLE
[ENH] object config interface

### DIFF
--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -76,7 +76,7 @@ class BaseObject(_FlagManager, _BaseEstimator):
 
     def __init__(self):
         """Construct BaseObject."""
-        self._tags_dynamic = {}
+        self._init_flags(flag_attr_name="_tags")
         super(BaseObject, self).__init__()
 
     def __eq__(self, other):

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -77,6 +77,7 @@ class BaseObject(_FlagManager, _BaseEstimator):
     def __init__(self):
         """Construct BaseObject."""
         self._init_flags(flag_attr_name="_tags")
+        self._init_flags(flag_attr_name="_config")
         super(BaseObject, self).__init__()
 
     def __eq__(self, other):
@@ -432,6 +433,38 @@ class BaseObject(_FlagManager, _BaseEstimator):
         self._clone_flags(
             estimator=estimator, flag_names=tag_names, flag_attr_name="_tags"
         )
+
+        return self
+
+    def get_config(self):
+        """Get config flags for self.
+
+        Returns
+        -------
+        config_dict : dict
+            Dictionary of config name : config value pairs. Collected from _config
+            class attribute via nested inheritance and then any overrides
+            and new tags from _onfig_dynamic object attribute.
+        """
+        return self._get_flags(flag_attr_name="_config")
+
+    def set_config(self, **config_dict):
+        """Set config flags to given values.
+
+        Parameters
+        ----------
+        config_dict : dict
+            Dictionary of config name : config value pairs.
+
+        Returns
+        -------
+        self : reference to self.
+
+        Notes
+        -----
+        Changes object state, copies configs in config_dict to self._config_dynamic.
+        """
+        self._set_flags(flag_attr_name="_config", **config_dict)
 
         return self
 

--- a/skbase/tests/conftest.py
+++ b/skbase/tests/conftest.py
@@ -83,7 +83,12 @@ SKBASE_PUBLIC_CLASSES_BY_MODULE = {
     ),
 }
 SKBASE_CLASSES_BY_MODULE = SKBASE_PUBLIC_CLASSES_BY_MODULE.copy()
-SKBASE_CLASSES_BY_MODULE.update({"skbase.base._meta": ("BaseMetaEstimator",)})
+SKBASE_CLASSES_BY_MODULE.update(
+    {
+        "skbase.base._meta": ("BaseMetaEstimator",),
+        "skbase.base._tagmanager": ("_FlagManager",),
+    }
+)
 SKBASE_PUBLIC_FUNCTIONS_BY_MODULE = {
     "skbase.lookup": ("all_objects", "get_package_metadata"),
     "skbase.lookup._lookup": ("all_objects", "get_package_metadata"),

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -1028,7 +1028,7 @@ def test_set_get_config():
 
     config_start = obj.get_config()
     assert isinstance(config_start, dict)
-    assert set(config_start.keys()) == set(["foo_config", "bar"])
+    assert set(config_start.keys()) == {"foo_config", "bar"}
     assert config_start["foo_config"] == 42
     assert config_start["bar"] == "a"
 
@@ -1038,7 +1038,7 @@ def test_set_get_config():
     obj.set_config(**{"bar": "b"})
     config_end = obj.get_config()
     assert isinstance(config_end, dict)
-    assert set(config_end.keys()) == set(["foo_config", "bar", "foobar"])
+    assert set(config_end.keys()) == {"foo_config", "bar", "foobar"}
     assert config_end["foo_config"] == 42
     assert config_end["bar"] == "b"
     assert config_end["foobar"] == 126

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -1003,6 +1003,47 @@ def test_has_implementation_of(
     assert not fixture_class_parent_instance._has_implementation_of("some_method")
 
 
+class ConfigTester(BaseObject):
+
+    _config = {"foo_config": 42, "bar": "a"}
+
+    clsvar = 210
+
+    def __init__(self, a, b=42):
+        self.a = a
+        self.b = b
+        self.c = 84
+
+
+def test_set_get_config():
+    """Test logic behind get_config, set_config.
+
+    Raises
+    ------
+    AssertionError if logic behind get_config, set_config is incorrect, logic tested:
+        calling get_fitted_params on a non-composite fittable returns the fitted param
+        calling get_fitted_params on a composite returns all nested params
+    """
+    obj = ConfigTester(4242)
+
+    config_start = obj.get_config()
+    assert isinstance(config_start, dict)
+    assert set(config_start.keys()) == set(["foo_config", "bar"])
+    assert config_start["foo_config"] == 42
+    assert config_start["bar"] == "a"
+
+    setconfig_return = obj.set_config(foobar=126)
+    assert obj is setconfig_return
+
+    obj.set_config(**{"bar": "b"})
+    config_end = obj.get_config()
+    assert isinstance(config_end, dict)
+    assert set(config_end.keys()) == set(["foo_config", "bar", "foobar"])
+    assert config_end["foo_config"] == 42
+    assert config_end["bar"] == "b"
+    assert config_end["foobar"] == 126
+
+
 class FittableCompositionDummy(BaseEstimator):
     """Potentially composite object, for testing."""
 


### PR DESCRIPTION
port of https://github.com/sktime/sktime/pull/3822 to `skbase`

This PR adds a config management capabilities to all `sktime` objects, similar to `sklearn`'s new config interface, via two methods `get_config` and `set_config`.

It is based on the flag manager mixin introduced in https://github.com/sktime/sktime/pull/3630 (ported to `skbase` in https://github.com/sktime/skbase/pull/138)

A STEP is available here: https://github.com/sktime/enhancement-proposals/pull/29

Includes:
* test for `get_config` and `set_config` interface