### PR TITLE
Add global config interface

### DIFF
--- a/skbase/config/__init__.py
+++ b/skbase/config/__init__.py
@@ -1,0 +1,404 @@
+# -*- coding: utf-8 -*-
+""":mod:`skbase.config` provides tools for global configuration of ``skbase``."""
+# -*- coding: utf-8 -*-
+# copyright: skbase developers, BSD-3-Clause License (see LICENSE file)
+# Includes functionality like get_config, set_config, and config_context
+# that is similar to scikit-learn. These elements are copyrighted by the
+# scikit-learn developers, BSD-3-Clause License. For conditions see
+# https://github.com/scikit-learn/scikit-learn/blob/main/COPYING
+import collections
+import sys
+import threading
+import warnings
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal  # type: ignore
+
+from skbase.utils._iter import _format_seq_to_str
+
+__author__: List[str] = ["RNKuhns"]
+
+
+@dataclass
+class GlobalConfigParamSetting:
+    """Define types of the setting information for a given config parameter."""
+
+    name: str
+    os_environ_name: str
+    expected_type: Union[type, Tuple[type]]
+    allowed_values: Optional[Tuple[Any, ...]]
+    default_value: Any
+
+    def get_allowed_values(self):
+        """Get `allowed_values` or empty tuple if `allowed_values` is None.
+
+        Returns
+        -------
+        tuple
+            Allowable values if any.
+        """
+        if self.allowed_values is None:
+            return ()
+        elif isinstance(self.allowed_values, tuple):
+            return self.allowed_values
+        elif isinstance(
+            self.allowed_values, collections.abc.Iterable
+        ) and not isinstance(self.allowed_values, str):
+            return tuple(self.allowed_values)
+        else:
+            return (self.allowed_values,)
+
+    def is_valid_param_value(self, value):
+        """Validate that a global configuration value is valid.
+
+        Verifies that the value set for a global configuration parameter is valid
+        based on the its configuration settings.
+
+        Returns
+        -------
+        bool
+            Whether a parameter value is valid.
+        """
+        allowed_values = self.get_allowed_values()
+
+        valid_param: bool
+        if not isinstance(value, self.expected_type):
+            valid_param = False
+        elif allowed_values is not None and value not in allowed_values:
+            valid_param = False
+        else:
+            valid_param = True
+        return valid_param
+
+    def get_valid_param_or_default(self, value):
+        """Validate `value` and return default if it is not valid."""
+        if self.is_valid_param_value(value):
+            return value
+        else:
+            msg = "Attempting to set an invalid value for a global configuration.\n"
+            msg += "Using default configuration value of parameter as a result.\n"
+            msg + f"When setting global config values for `{self.name}`, the values "
+            msg += f"should be of type {self.expected_type}."
+            if self.allowed_values is not None:
+                values_str = _format_seq_to_str(
+                    self.get_allowed_values(), last_sep="or", remove_type_text=True
+                )
+                msg += f"Allowed values are be one of {values_str}."
+            warnings.warn(msg, UserWarning, stacklevel=2)
+            return self.default_value
+
+
+_CONFIG_REGISTRY: Dict[str, GlobalConfigParamSetting] = {
+    "print_changed_only": GlobalConfigParamSetting(
+        name="print_changed_only",
+        os_environ_name="SKBASE_PRINT_CHANGED_ONLY",
+        expected_type=bool,
+        allowed_values=(True, False),
+        default_value=True,
+    ),
+    "display": GlobalConfigParamSetting(
+        name="display",
+        os_environ_name="SKBASE_OBJECT_DISPLAY",
+        expected_type=str,
+        allowed_values=("text", "diagram"),
+        default_value="text",
+    ),
+}
+
+_DEFAULT_GLOBAL_CONFIG: Dict[str, Any] = {
+    config_name: config_info.default_value
+    for config_name, config_info in _CONFIG_REGISTRY.items()
+}
+
+global_config = _DEFAULT_GLOBAL_CONFIG.copy()
+_THREAD_LOCAL_DATA = threading.local()
+
+
+def _get_threadlocal_config() -> Dict[str, Any]:
+    """Get a threadlocal **mutable** configuration.
+
+    If the configuration does not exist, copy the default global configuration.
+
+    Returns
+    -------
+    dict
+        Threadlocal global config or copy of default global configuration.
+    """
+    if not hasattr(_THREAD_LOCAL_DATA, "global_config"):
+        _THREAD_LOCAL_DATA.global_config = global_config.copy()
+    return _THREAD_LOCAL_DATA.global_config
+
+
+def get_config_os_env_names() -> List[str]:
+    """Retrieve the os environment names for configurable settings.
+
+    Returns
+    -------
+    env_names : list
+        The os environment names that can be used to set configurable settings.
+
+    See Also
+    --------
+    config_context :
+        Configuration context manager.
+    get_default_config :
+        Retrieve ``skbase``'s default configuration.
+    get_config :
+        Retrieve current global configuration values.
+    set_config :
+        Set global configuration.
+    reset_config :
+        Reset configuration to ``skbase`` default.
+
+    Examples
+    --------
+    >>> from skbase.config import get_config_os_env_names
+    >>> get_config_os_env_names()
+    ['SKBASE_PRINT_CHANGED_ONLY', 'SKBASE_OBJECT_DISPLAY']
+    """
+    return [config_info.os_environ_name for config_info in _CONFIG_REGISTRY.values()]
+
+
+def get_default_config() -> Dict[str, Any]:
+    """Retrive the default global configuration.
+
+    This will always return the default ``skbase`` global configuration.
+
+    Returns
+    -------
+    config : dict
+        The default configurable settings (keys) and their default values (values).
+
+    See Also
+    --------
+    config_context :
+        Configuration context manager.
+    get_config :
+        Retrieve current global configuration values.
+    get_config_os_env_names :
+        Retrieve os environment names that can be used to set configuration.
+    set_config :
+        Set global configuration.
+    reset_config :
+        Reset configuration to ``skbase`` default.
+
+    Examples
+    --------
+    >>> from skbase.config import get_default_config
+    >>> get_default_config()
+    {'print_changed_only': True, 'display': 'text'}
+    """
+    return _DEFAULT_GLOBAL_CONFIG.copy()
+
+
+def get_config() -> Dict[str, Any]:
+    """Retrieve current values for configuration set by :meth:`set_config`.
+
+    Willr return the default configuration if know updated configuration has
+    been set by :meth:`set_config`.
+
+    Returns
+    -------
+    config : dict
+        The configurable settings (keys) and their default values (values).
+
+    See Also
+    --------
+    config_context :
+        Configuration context manager.
+    get_default_config :
+        Retrieve ``skbase``'s default configuration.
+    get_config_os_env_names :
+        Retrieve os environment names that can be used to set configuration.
+    set_config :
+        Set global configuration.
+    reset_config :
+        Reset configuration to ``skbase`` default.
+
+    Examples
+    --------
+    >>> from skbase.config import get_config
+    >>> get_config()
+    {'print_changed_only': True, 'display': 'text'}
+    """
+    return _get_threadlocal_config().copy()
+
+
+def set_config(
+    print_changed_only: Optional[bool] = None,
+    display: Literal["text", "diagram"] = None,
+    local_threadsafe: bool = False,
+) -> None:
+    """Set global configuration.
+
+    Allows the ``skbase`` global configuration to be updated.
+
+    Parameters
+    ----------
+    print_changed_only : bool, default=None
+        If True, only the parameters that were set to non-default
+        values will be printed when printing a BaseObject instance. For example,
+        ``print(SVC())`` while True will only print 'SVC()', but would print
+        'SVC(C=1.0, cache_size=200, ...)' with all the non-changed parameters
+        when False. If None, the existing value won't change.
+    display : {'text', 'diagram'}, default=None
+        If 'diagram', instances inheritting from BaseOBject will be displayed
+        as a diagram in a Jupyter lab or notebook context. If 'text', instances
+        inheritting from BaseObject will be displayed as text. If None, the
+        existing value won't change.
+    local_threadsafe : bool, default=False
+        If False, set the backend as default for all threads.
+
+    Returns
+    -------
+    None
+        No output returned.
+
+    See Also
+    --------
+    config_context :
+        Configuration context manager.
+    get_default_config :
+        Retrieve ``skbase``'s default configuration.
+    get_config :
+        Retrieve current global configuration values.
+    get_config_os_env_names :
+        Retrieve os environment names that can be used to set configuration.
+    reset_config :
+        Reset configuration to default.
+
+    Examples
+    --------
+    >>> from skbase.config import get_config, set_config
+    >>> get_config()
+    {'print_changed_only': True, 'display': 'text'}
+    >>> set_config(display='diagram')
+    >>> get_config()
+    {'print_changed_only': True, 'display': 'diagram'}
+    """
+    local_config = _get_threadlocal_config()
+
+    if print_changed_only is not None:
+        local_config["print_changed_only"] = _CONFIG_REGISTRY[
+            "print_changed_only"
+        ].get_valid_param_or_default(print_changed_only)
+    if display is not None:
+        local_config["display"] = _CONFIG_REGISTRY[
+            "display"
+        ].get_valid_param_or_default(display)
+
+    if not local_threadsafe:
+        global_config.update(local_config)
+
+    return None
+
+
+def reset_config() -> None:
+    """Reset the global configuration to the default.
+
+    Will remove any user updates to the global configuration and reset the values
+    back to the ``skbase`` defaults.
+
+    Returns
+    -------
+    None
+        No output returned.
+
+    See Also
+    --------
+    config_context :
+        Configuration context manager.
+    get_default_config :
+        Retrieve ``skbase``'s default configuration.
+    get_config :
+        Retrieve current global configuration values.
+    get_config_os_env_names :
+        Retrieve os environment names that can be used to set configuration.
+    set_config :
+        Set global configuration.
+
+    Examples
+    --------
+    >>> from skbase.config import get_config, set_config, reset_config
+    >>> get_config()
+    {'print_changed_only': True, 'display': 'text'}
+    >>> set_config(display='diagram')
+    >>> get_config()
+    {'print_changed_only': True, 'display': 'diagram'}
+    >>> reset_config()
+    >>> get_config()
+    {'print_changed_only': True, 'display': 'text'}
+    """
+    default_config = get_default_config()
+    set_config(**default_config)
+    return None
+
+
+@contextmanager
+def config_context(
+    print_changed_only: Optional[bool] = None,
+    display: Literal["text", "diagram"] = None,
+    local_threadsafe: bool = False,
+) -> Iterator[None]:
+    """Context manager for global configuration.
+
+    Parameters
+    ----------
+    print_changed_only : bool, default=None
+        If True, only the parameters that were set to non-default
+        values will be printed when printing a BaseObject instance. For example,
+        ``print(SVC())`` while True will only print 'SVC()', but would print
+        'SVC(C=1.0, cache_size=200, ...)' with all the non-changed parameters
+        when False. If None, the existing value won't change.
+    display : {'text', 'diagram'}, default=None
+        If 'diagram', instances inheritting from BaseOBject will be displayed
+        as a diagram in a Jupyter lab or notebook context. If 'text', instances
+        inheritting from BaseObject will be displayed as text. If None, the
+        existing value won't change.
+    local_threadsafe : bool, default=False
+        If False, set the config as default for all threads.
+
+    Yields
+    ------
+    None
+
+    See Also
+    --------
+    get_default_config :
+        Retrieve ``skbase``'s default configuration.
+    get_config :
+        Retrieve current values of the global configuration.
+    get_config_os_env_names :
+        Retrieve os environment names that can be used to set configuration.
+    set_config :
+        Set global configuration.
+    reset_config :
+        Reset configuration to ``skbase`` default.
+
+    Notes
+    -----
+    All settings, not just those presently modified, will be returned to
+    their previous values when the context manager is exited.
+
+    Examples
+    --------
+    >>> from skbase.config import config_context
+    >>> with config_context(display='diagram'):
+    ...     pass
+    """
+    old_config = get_config()
+    set_config(
+        print_changed_only=print_changed_only,
+        display=display,
+        local_threadsafe=local_threadsafe,
+    )
+
+    try:
+        yield
+    finally:
+        set_config(**old_config)

--- a/skbase/config/__init__.py
+++ b/skbase/config/__init__.py
@@ -134,36 +134,6 @@ def _get_threadlocal_config() -> Dict[str, Any]:
     return _THREAD_LOCAL_DATA.global_config
 
 
-def get_config_os_env_names() -> List[str]:
-    """Retrieve the os environment names for configurable settings.
-
-    Returns
-    -------
-    env_names : list
-        The os environment names that can be used to set configurable settings.
-
-    See Also
-    --------
-    config_context :
-        Configuration context manager.
-    get_default_config :
-        Retrieve ``skbase``'s default configuration.
-    get_config :
-        Retrieve current global configuration values.
-    set_config :
-        Set global configuration.
-    reset_config :
-        Reset configuration to ``skbase`` default.
-
-    Examples
-    --------
-    >>> from skbase.config import get_config_os_env_names
-    >>> get_config_os_env_names()
-    ['SKBASE_PRINT_CHANGED_ONLY', 'SKBASE_OBJECT_DISPLAY']
-    """
-    return [config_info.os_environ_name for config_info in _CONFIG_REGISTRY.values()]
-
-
 def get_default_config() -> Dict[str, Any]:
     """Retrive the default global configuration.
 
@@ -180,8 +150,6 @@ def get_default_config() -> Dict[str, Any]:
         Configuration context manager.
     get_config :
         Retrieve current global configuration values.
-    get_config_os_env_names :
-        Retrieve os environment names that can be used to set configuration.
     set_config :
         Set global configuration.
     reset_config :
@@ -213,8 +181,6 @@ def get_config() -> Dict[str, Any]:
         Configuration context manager.
     get_default_config :
         Retrieve ``skbase``'s default configuration.
-    get_config_os_env_names :
-        Retrieve os environment names that can be used to set configuration.
     set_config :
         Set global configuration.
     reset_config :
@@ -267,8 +233,6 @@ def set_config(
         Retrieve ``skbase``'s default configuration.
     get_config :
         Retrieve current global configuration values.
-    get_config_os_env_names :
-        Retrieve os environment names that can be used to set configuration.
     reset_config :
         Reset configuration to default.
 
@@ -317,8 +281,6 @@ def reset_config() -> None:
         Retrieve ``skbase``'s default configuration.
     get_config :
         Retrieve current global configuration values.
-    get_config_os_env_names :
-        Retrieve os environment names that can be used to set configuration.
     set_config :
         Set global configuration.
 
@@ -373,8 +335,6 @@ def config_context(
         Retrieve ``skbase``'s default configuration.
     get_config :
         Retrieve current values of the global configuration.
-    get_config_os_env_names :
-        Retrieve os environment names that can be used to set configuration.
     set_config :
         Set global configuration.
     reset_config :

--- a/skbase/config/tests/__init__.py
+++ b/skbase/config/tests/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3 -u
+# -*- coding: utf-8 -*-
+# copyright: skbase developers, BSD-3-Clause License (see LICENSE file)
+"""Test functionality of :mod:`skbase.config`."""

--- a/skbase/config/tests/test_config.py
+++ b/skbase/config/tests/test_config.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+"""Test configuration functionality."""
+import pytest
+
+from skbase.config import (
+    _CONFIG_REGISTRY,
+    _DEFAULT_GLOBAL_CONFIG,
+    GlobalConfigParamSetting,
+    config_context,
+    get_config,
+    get_config_os_env_names,
+    get_default_config,
+    reset_config,
+    set_config,
+)
+
+PRINT_CHANGE_ONLY_VALUES = _CONFIG_REGISTRY["print_changed_only"].get_allowed_values()
+DISPLAY_VALUES = _CONFIG_REGISTRY["display"].get_allowed_values()
+
+
+@pytest.fixture
+def config_registry():
+    """Config registry fixture."""
+    return _CONFIG_REGISTRY
+
+
+@pytest.fixture
+def global_config_default():
+    """Config registry fixture."""
+    return _DEFAULT_GLOBAL_CONFIG
+
+
+@pytest.mark.parametrize("allowed_values", (None, (), "something", range(1, 8)))
+def test_global_config_param_get_allowed_values(allowed_values):
+    """Test GlobalConfigParamSetting behavior works as expected."""
+    some_config_param = GlobalConfigParamSetting(
+        name="some_param",
+        os_environ_name="SKBASE_OBJECT_DISPLAY",
+        expected_type=str,
+        allowed_values=allowed_values,
+        default_value="text",
+    )
+    # Verify we always coerce output of get_allowed_values to tuple
+    values = some_config_param.get_allowed_values()
+    assert isinstance(values, tuple)
+
+
+@pytest.mark.parametrize("value", (None, (), "wrong_string", "text", range(1, 8)))
+def test_global_config_param_is_valid_param_value(value):
+    """Test GlobalConfigParamSetting behavior works as expected."""
+    some_config_param = GlobalConfigParamSetting(
+        name="some_param",
+        os_environ_name="SKBASE_OBJECT_DISPLAY",
+        expected_type=str,
+        allowed_values=("text", "diagram"),
+        default_value="text",
+    )
+    # Verify we correctly identify invalid parameters
+    if value in ("text", "diagram"):
+        expected_valid = True
+    else:
+        expected_valid = False
+    assert some_config_param.is_valid_param_value(value) == expected_valid
+
+
+def test_get_config_os_env_names(config_registry):
+    """Verify that get_config_os_env_names returns expected values."""
+    os_env_names = get_config_os_env_names()
+    expected_os_env_names = [
+        config_info.os_environ_name for config_info in config_registry.values()
+    ]
+    msg = "`get_config_os_env_names` does not return expected value.\n"
+    msg += f"Expected {expected_os_env_names}, but returned {os_env_names}."
+    assert os_env_names == expected_os_env_names, msg
+
+
+def test_get_default_config(global_config_default):
+    """Verify that get_default_config returns default global config values."""
+    retrieved_default = get_default_config()
+    msg = "`get_default_config` does not return expected values.\n"
+    msg += f"Expected {global_config_default}, but returned {retrieved_default}."
+    assert retrieved_default == global_config_default, msg
+
+
+@pytest.mark.parametrize("print_changed_only", PRINT_CHANGE_ONLY_VALUES)
+@pytest.mark.parametrize("display", DISPLAY_VALUES)
+def test_set_config_then_get_config_returns_expected_value(print_changed_only, display):
+    """Verify that get_config returns set config values if set_config run."""
+    set_config(print_changed_only=print_changed_only, display=display)
+    retrieved_default = get_config()
+    expected_config = {"print_changed_only": print_changed_only, "display": display}
+    msg = "`get_config` used after `set_config` does not return expected values.\n"
+    msg += "After set_config is run, get_config should return the set values.\n "
+    msg += f"Expected {expected_config}, but returned {retrieved_default}."
+    assert retrieved_default == expected_config, msg
+
+
+@pytest.mark.parametrize("print_changed_only", PRINT_CHANGE_ONLY_VALUES)
+@pytest.mark.parametrize("display", DISPLAY_VALUES)
+def test_reset_config_resets_the_config(print_changed_only, display):
+    """Verify that get_config returns default config if reset_config run."""
+    default_config = get_default_config()
+    set_config(print_changed_only=print_changed_only, display=display)
+    reset_config()
+    retrieved_config = get_config()
+
+    msg = "`get_config` does not return expected values after `reset_config`.\n"
+    msg += "`After reset_config is run, get_config` should return defaults.\n"
+    msg += f"Expected {default_config}, but returned {retrieved_config}."
+    assert retrieved_config == default_config, msg
+    reset_config()
+
+
+@pytest.mark.parametrize("print_changed_only", PRINT_CHANGE_ONLY_VALUES)
+@pytest.mark.parametrize("display", DISPLAY_VALUES)
+def test_config_context(print_changed_only, display):
+    """Verify that config_context affects context but not overall configuration."""
+    # Make sure config is reset to default values then retrieve it
+    reset_config()
+    retrieved_config = get_config()
+    # Now lets make sure the config_context is changing the context of those values
+    # within the scope of the context manager as expected
+    for print_changed_only in (True, False):
+        with config_context(print_changed_only=print_changed_only, display=display):
+            retrieved_context_config = get_config()
+        expected_config = {"print_changed_only": print_changed_only, "display": display}
+        msg = "`get_config` does not return expected values within `config_context`.\n"
+        msg += "`get_config` should return config defined by `config_context`.\n"
+        msg += f"Expected {expected_config}, but returned {retrieved_context_config}."
+        assert retrieved_context_config == expected_config, msg
+
+    # Outside of the config_context we should have not affected the retrieved config
+    # set by call to reset_config()
+    config_post_config_context = get_config()
+    msg = "`get_config` does not return expected values after `config_context`a.\n"
+    msg += "`config_context` should not affect configuration outside its context.\n"
+    msg += f"Expected {config_post_config_context}, but returned {retrieved_config}."
+    assert retrieved_config == config_post_config_context, msg
+    reset_config()
+
+
+def test_set_config_behavior_invalid_value():
+    """Test set_config uses default and raises warning when setting invalid value."""
+    reset_config()
+    with pytest.warns(UserWarning, match=r"Attempting to set an invalid value.*"):
+        set_config(print_changed_only="False")
+
+    assert get_config() == get_default_config()
+
+    with pytest.warns(UserWarning, match=r"Attempting to set an invalid value.*"):
+        set_config(print_changed_only=7)
+
+    assert get_config() == get_default_config()
+    reset_config()

--- a/skbase/config/tests/test_config.py
+++ b/skbase/config/tests/test_config.py
@@ -8,7 +8,6 @@ from skbase.config import (
     GlobalConfigParamSetting,
     config_context,
     get_config,
-    get_config_os_env_names,
     get_default_config,
     reset_config,
     set_config,
@@ -63,23 +62,11 @@ def test_global_config_param_is_valid_param_value(value):
     assert some_config_param.is_valid_param_value(value) == expected_valid
 
 
-def test_get_config_os_env_names(config_registry):
-    """Verify that get_config_os_env_names returns expected values."""
-    os_env_names = get_config_os_env_names()
-    expected_os_env_names = [
-        config_info.os_environ_name for config_info in config_registry.values()
-    ]
-    msg = "`get_config_os_env_names` does not return expected value.\n"
-    msg += f"Expected {expected_os_env_names}, but returned {os_env_names}."
-    assert os_env_names == expected_os_env_names, msg
-
-
 def test_get_default_config(global_config_default):
-    """Verify that get_default_config returns default global config values."""
-    retrieved_default = get_default_config()
-    msg = "`get_default_config` does not return expected values.\n"
-    msg += f"Expected {global_config_default}, but returned {retrieved_default}."
-    assert retrieved_default == global_config_default, msg
+    """Test get_default_config alwasy returns the default config."""
+    assert get_default_config() == global_config_default
+    set_config(print_changed_only=False)
+    assert get_default_config() == global_config_default
 
 
 @pytest.mark.parametrize("print_changed_only", PRINT_CHANGE_ONLY_VALUES)
@@ -97,17 +84,18 @@ def test_set_config_then_get_config_returns_expected_value(print_changed_only, d
 
 @pytest.mark.parametrize("print_changed_only", PRINT_CHANGE_ONLY_VALUES)
 @pytest.mark.parametrize("display", DISPLAY_VALUES)
-def test_reset_config_resets_the_config(print_changed_only, display):
+def test_reset_config_resets_the_config(
+    print_changed_only, display, global_config_default
+):
     """Verify that get_config returns default config if reset_config run."""
-    default_config = get_default_config()
     set_config(print_changed_only=print_changed_only, display=display)
     reset_config()
     retrieved_config = get_config()
 
     msg = "`get_config` does not return expected values after `reset_config`.\n"
     msg += "`After reset_config is run, get_config` should return defaults.\n"
-    msg += f"Expected {default_config}, but returned {retrieved_config}."
-    assert retrieved_config == default_config, msg
+    msg += f"Expected {global_config_default}, but returned {retrieved_config}."
+    assert retrieved_config == global_config_default, msg
     reset_config()
 
 

--- a/skbase/tests/conftest.py
+++ b/skbase/tests/conftest.py
@@ -23,6 +23,7 @@ SKBASE_MODULES = (
     "skbase.base._base",
     "skbase.base._meta",
     "skbase.base._tagmanager",
+    "skbase.config",
     "skbase.lookup",
     "skbase.lookup.tests",
     "skbase.lookup.tests.test_lookup",
@@ -51,6 +52,7 @@ SKBASE_MODULES = (
 SKBASE_PUBLIC_MODULES = (
     "skbase",
     "skbase.base",
+    "skbase.config",
     "skbase.lookup",
     "skbase.lookup.tests",
     "skbase.lookup.tests.test_lookup",
@@ -74,6 +76,7 @@ SKBASE_PUBLIC_CLASSES_BY_MODULE = {
     "skbase.base": ("BaseEstimator", "BaseMetaEstimator", "BaseObject"),
     "skbase.base._base": ("BaseEstimator", "BaseObject"),
     "skbase.base._meta": ("BaseMetaEstimator",),
+    "skbase.config": ("GlobalConfigParamSetting",),
     "skbase.lookup._lookup": ("ClassInfo", "FunctionInfo", "ModuleInfo"),
     "skbase.testing": ("BaseFixtureGenerator", "QuickTester", "TestAllObjects"),
     "skbase.testing.test_all_objects": (
@@ -85,11 +88,17 @@ SKBASE_PUBLIC_CLASSES_BY_MODULE = {
 SKBASE_CLASSES_BY_MODULE = SKBASE_PUBLIC_CLASSES_BY_MODULE.copy()
 SKBASE_CLASSES_BY_MODULE.update(
     {
-        "skbase.base._meta": ("BaseMetaEstimator",),
         "skbase.base._tagmanager": ("_FlagManager",),
     }
 )
 SKBASE_PUBLIC_FUNCTIONS_BY_MODULE = {
+    "skbase.config": (
+        "get_config",
+        "get_default_config",
+        "set_config",
+        "reset_config",
+        "config_context",
+    ),
     "skbase.lookup": ("all_objects", "get_package_metadata"),
     "skbase.lookup._lookup": ("all_objects", "get_package_metadata"),
     "skbase.testing.utils._conditional_fixtures": (
@@ -124,6 +133,14 @@ SKBASE_PUBLIC_FUNCTIONS_BY_MODULE = {
 SKBASE_FUNCTIONS_BY_MODULE = SKBASE_PUBLIC_FUNCTIONS_BY_MODULE.copy()
 SKBASE_FUNCTIONS_BY_MODULE.update(
     {
+        "skbase.config": (
+            "_get_threadlocal_config",
+            "get_config",
+            "get_default_config",
+            "set_config",
+            "reset_config",
+            "config_context",
+        ),
         "skbase.lookup._lookup": (
             "_determine_module_path",
             "_get_return_tags",

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -69,6 +69,7 @@ __all__ = [
 
 import inspect
 from copy import deepcopy
+from typing import Any, Dict, Type
 
 import numpy as np
 import pytest
@@ -79,6 +80,7 @@ from sklearn import config_context
 from sklearn.base import clone
 
 from skbase.base import BaseEstimator, BaseObject
+from skbase.config import get_config
 from skbase.tests.conftest import Child, Parent
 from skbase.tests.mock_package.test_mock_package import CompositionDummy
 
@@ -200,13 +202,13 @@ def fixture_reset_tester():
 
 
 @pytest.fixture
-def fixture_class_child_tags(fixture_class_child):
+def fixture_class_child_tags(fixture_class_child: Type[Child]):
     """Pytest fixture for tags of Child."""
     return fixture_class_child.get_class_tags()
 
 
 @pytest.fixture
-def fixture_object_instance_set_tags(fixture_tag_class_object):
+def fixture_object_instance_set_tags(fixture_tag_class_object: Child):
     """Fixture class instance to test tag setting."""
     fixture_tag_set = {"A": 42424243, "E": 3}
     return fixture_tag_class_object.set_tags(**fixture_tag_set)
@@ -266,7 +268,9 @@ def fixture_class_instance_no_param_interface():
     return NoParamInterface()
 
 
-def test_get_class_tags(fixture_class_child, fixture_class_child_tags):
+def test_get_class_tags(
+    fixture_class_child: Type[Child], fixture_class_child_tags: Any
+):
     """Test get_class_tags class method of BaseObject for correctness.
 
     Raises
@@ -280,7 +284,7 @@ def test_get_class_tags(fixture_class_child, fixture_class_child_tags):
     assert child_tags == fixture_class_child_tags, msg
 
 
-def test_get_class_tag(fixture_class_child, fixture_class_child_tags):
+def test_get_class_tag(fixture_class_child: Type[Child], fixture_class_child_tags: Any):
     """Test get_class_tag class method of BaseObject for correctness.
 
     Raises
@@ -307,7 +311,7 @@ def test_get_class_tag(fixture_class_child, fixture_class_child_tags):
     assert child_tag_default_none is None, msg
 
 
-def test_get_tags(fixture_tag_class_object, fixture_object_tags):
+def test_get_tags(fixture_tag_class_object: Child, fixture_object_tags: Dict[str, Any]):
     """Test get_tags method of BaseObject for correctness.
 
     Raises
@@ -321,7 +325,7 @@ def test_get_tags(fixture_tag_class_object, fixture_object_tags):
     assert object_tags == fixture_object_tags, msg
 
 
-def test_get_tag(fixture_tag_class_object, fixture_object_tags):
+def test_get_tag(fixture_tag_class_object: Child, fixture_object_tags: Dict[str, Any]):
     """Test get_tag method of BaseObject for correctness.
 
     Raises
@@ -351,7 +355,7 @@ def test_get_tag(fixture_tag_class_object, fixture_object_tags):
     assert object_tag_default_none is None, msg
 
 
-def test_get_tag_raises(fixture_tag_class_object):
+def test_get_tag_raises(fixture_tag_class_object: Child):
     """Test that get_tag method raises error for unknown tag.
 
     Raises
@@ -363,9 +367,9 @@ def test_get_tag_raises(fixture_tag_class_object):
 
 
 def test_set_tags(
-    fixture_object_instance_set_tags,
-    fixture_object_set_tags,
-    fixture_object_dynamic_tags,
+    fixture_object_instance_set_tags: Any,
+    fixture_object_set_tags: Dict[str, Any],
+    fixture_object_dynamic_tags: Dict[str, int],
 ):
     """Test set_tags method of BaseObject for correctness.
 
@@ -381,7 +385,9 @@ def test_set_tags(
     assert fixture_object_instance_set_tags.get_tags() == fixture_object_set_tags, msg
 
 
-def test_set_tags_works_with_missing_tags_dynamic_attribute(fixture_tag_class_object):
+def test_set_tags_works_with_missing_tags_dynamic_attribute(
+    fixture_tag_class_object: Child,
+):
     """Test set_tags will still work if _tags_dynamic is missing."""
     base_obj = deepcopy(fixture_tag_class_object)
     delattr(base_obj, "_tags_dynamic")
@@ -460,7 +466,7 @@ def test_clone_tags():
         assert test_obj_tags.get(tag) == another_base_obj_tags[tag]
 
 
-def test_is_composite(fixture_composition_dummy):
+def test_is_composite(fixture_composition_dummy: Type[CompositionDummy]):
     """Test is_composite tag for correctness.
 
     Raises
@@ -474,7 +480,11 @@ def test_is_composite(fixture_composition_dummy):
     assert composite.is_composite()
 
 
-def test_components(fixture_object, fixture_class_parent, fixture_composition_dummy):
+def test_components(
+    fixture_object: Type[BaseObject],
+    fixture_class_parent: Type[Parent],
+    fixture_composition_dummy: Type[CompositionDummy],
+):
     """Test component retrieval.
 
     Raises
@@ -507,7 +517,7 @@ def test_components(fixture_object, fixture_class_parent, fixture_composition_du
 
 
 def test_components_raises_error_base_class_is_not_class(
-    fixture_object, fixture_composition_dummy
+    fixture_object: Type[BaseObject], fixture_composition_dummy: Type[CompositionDummy]
 ):
     """Test _component method raises error if base_class param is not class."""
     non_composite = fixture_composition_dummy(foo=42)
@@ -526,7 +536,7 @@ def test_components_raises_error_base_class_is_not_class(
 
 
 def test_components_raises_error_base_class_is_not_baseobject_subclass(
-    fixture_composition_dummy,
+    fixture_composition_dummy: Type[CompositionDummy],
 ):
     """Test _component method raises error if base_class is not BaseObject subclass."""
 
@@ -540,7 +550,7 @@ def test_components_raises_error_base_class_is_not_baseobject_subclass(
 
 # Test parameter interface (get_params, set_params, reset and related methods)
 # Some tests of get_params and set_params are adapted from sklearn tests
-def test_reset(fixture_reset_tester):
+def test_reset(fixture_reset_tester: Type[ResetTester]):
     """Test reset method for correct behaviour, on a simple estimator.
 
     Raises
@@ -567,7 +577,7 @@ def test_reset(fixture_reset_tester):
     assert hasattr(x, "foo")
 
 
-def test_reset_composite(fixture_reset_tester):
+def test_reset_composite(fixture_reset_tester: Type[ResetTester]):
     """Test reset method for correct behaviour, on a composite estimator."""
     y = fixture_reset_tester(42)
     x = fixture_reset_tester(a=y)
@@ -582,7 +592,7 @@ def test_reset_composite(fixture_reset_tester):
     assert not hasattr(x.a, "d")
 
 
-def test_get_init_signature(fixture_class_parent):
+def test_get_init_signature(fixture_class_parent: Type[Parent]):
     """Test error is raised when invalid init signature is used."""
     init_sig = fixture_class_parent._get_init_signature()
     init_sig_is_list = isinstance(init_sig, list)
@@ -594,14 +604,18 @@ def test_get_init_signature(fixture_class_parent):
     ), "`_get_init_signature` is not returning expected result."
 
 
-def test_get_init_signature_raises_error_for_invalid_signature(fixture_invalid_init):
+def test_get_init_signature_raises_error_for_invalid_signature(
+    fixture_invalid_init: Type[InvalidInitSignatureTester],
+):
     """Test error is raised when invalid init signature is used."""
     with pytest.raises(RuntimeError):
         fixture_invalid_init._get_init_signature()
 
 
 def test_get_param_names(
-    fixture_object, fixture_class_parent, fixture_class_parent_expected_params
+    fixture_object: Type[BaseObject],
+    fixture_class_parent: Type[Parent],
+    fixture_class_parent_expected_params: Dict[str, Any],
 ):
     """Test that get_param_names returns list of string parameter names."""
     param_names = fixture_class_parent.get_param_names()
@@ -612,10 +626,10 @@ def test_get_param_names(
 
 
 def test_get_params(
-    fixture_class_parent,
-    fixture_class_parent_expected_params,
-    fixture_class_instance_no_param_interface,
-    fixture_composition_dummy,
+    fixture_class_parent: Type[Parent],
+    fixture_class_parent_expected_params: Dict[str, Any],
+    fixture_class_instance_no_param_interface: NoParamInterface,
+    fixture_composition_dummy: Type[CompositionDummy],
 ):
     """Test get_params returns expected parameters."""
     # Simple test of returned params
@@ -638,7 +652,10 @@ def test_get_params(
     assert "foo" in params and "bar" in params and len(params) == 2
 
 
-def test_get_params_invariance(fixture_class_parent, fixture_composition_dummy):
+def test_get_params_invariance(
+    fixture_class_parent: Type[Parent],
+    fixture_composition_dummy: Type[CompositionDummy],
+):
     """Test that get_params(deep=False) is subset of get_params(deep=True)."""
     composite = fixture_composition_dummy(foo=fixture_class_parent(), bar=84)
     shallow_params = composite.get_params(deep=False)
@@ -646,7 +663,7 @@ def test_get_params_invariance(fixture_class_parent, fixture_composition_dummy):
     assert all(item in deep_params.items() for item in shallow_params.items())
 
 
-def test_get_params_after_set_params(fixture_class_parent):
+def test_get_params_after_set_params(fixture_class_parent: Type[Parent]):
     """Test that get_params returns the same thing before and after set_params.
 
     Based on scikit-learn check in check_estimator.
@@ -687,9 +704,9 @@ def test_get_params_after_set_params(fixture_class_parent):
 
 
 def test_set_params(
-    fixture_class_parent,
-    fixture_class_parent_expected_params,
-    fixture_composition_dummy,
+    fixture_class_parent: Type[Parent],
+    fixture_class_parent_expected_params: Dict[str, Any],
+    fixture_composition_dummy: Type[CompositionDummy],
 ):
     """Test set_params works as expected."""
     # Simple case of setting a parameter
@@ -711,7 +728,8 @@ def test_set_params(
 
 
 def test_set_params_raises_error_non_existent_param(
-    fixture_class_parent_instance, fixture_composition_dummy
+    fixture_class_parent_instance: Parent,
+    fixture_composition_dummy: Type[CompositionDummy],
 ):
     """Test set_params raises an error when passed a non-existent parameter name."""
     # non-existing parameter in svc
@@ -727,7 +745,8 @@ def test_set_params_raises_error_non_existent_param(
 
 
 def test_set_params_raises_error_non_interface_composite(
-    fixture_class_instance_no_param_interface, fixture_composition_dummy
+    fixture_class_instance_no_param_interface: NoParamInterface,
+    fixture_composition_dummy: Type[CompositionDummy],
 ):
     """Test set_params raises error when setting param of non-conforming composite."""
     # When a composite is made up of a class that doesn't have the BaseObject
@@ -753,7 +772,9 @@ def test_raises_on_get_params_for_param_arg_not_assigned_to_attribute():
         est.get_params()
 
 
-def test_set_params_with_no_param_to_set_returns_object(fixture_class_parent):
+def test_set_params_with_no_param_to_set_returns_object(
+    fixture_class_parent: Type[Parent],
+):
     """Test set_params correctly returns self when no parameters are set."""
     base_obj = fixture_class_parent()
     orig_params = deepcopy(base_obj.get_params())
@@ -767,7 +788,7 @@ def test_set_params_with_no_param_to_set_returns_object(fixture_class_parent):
 # This section tests the clone functionality
 # These have been adapted from sklearn's tests of clone to use the clone
 # method that is included as part of the BaseObject interface
-def test_clone(fixture_class_parent_instance):
+def test_clone(fixture_class_parent_instance: Parent):
     """Test that clone is making a deep copy as expected."""
     # Creates a BaseObject and makes a copy of its original state
     # (which, in this case, is the current state of the BaseObject),
@@ -777,7 +798,7 @@ def test_clone(fixture_class_parent_instance):
     assert fixture_class_parent_instance.get_params() == new_base_obj.get_params()
 
 
-def test_clone_2(fixture_class_parent_instance):
+def test_clone_2(fixture_class_parent_instance: Parent):
     """Test that clone does not copy attributes not set in constructor."""
     # We first create an estimator, give it an own attribute, and
     # make a copy of its original state. Then we check that the copy doesn't
@@ -790,7 +811,9 @@ def test_clone_2(fixture_class_parent_instance):
 
 
 def test_clone_raises_error_for_nonconforming_objects(
-    fixture_invalid_init, fixture_buggy, fixture_modify_param
+    fixture_invalid_init: Type[InvalidInitSignatureTester],
+    fixture_buggy: Type[Buggy],
+    fixture_modify_param: Type[ModifyParam],
 ):
     """Test that clone raises an error on nonconforming BaseObjects."""
     buggy = fixture_buggy()
@@ -807,7 +830,7 @@ def test_clone_raises_error_for_nonconforming_objects(
         obj_that_modifies.clone()
 
 
-def test_clone_param_is_none(fixture_class_parent):
+def test_clone_param_is_none(fixture_class_parent: Type[Parent]):
     """Test clone with keyword parameter set to None."""
     base_obj = fixture_class_parent(c=None)
     new_base_obj = clone(base_obj)
@@ -816,7 +839,7 @@ def test_clone_param_is_none(fixture_class_parent):
     assert base_obj.c is new_base_obj2.c
 
 
-def test_clone_empty_array(fixture_class_parent):
+def test_clone_empty_array(fixture_class_parent: Type[Parent]):
     """Test clone with keyword parameter is scipy sparse matrix.
 
     This test is based on scikit-learn regression test to make sure clone
@@ -830,7 +853,7 @@ def test_clone_empty_array(fixture_class_parent):
     np.testing.assert_array_equal(base_obj.c, new_base_obj2.c)
 
 
-def test_clone_sparse_matrix(fixture_class_parent):
+def test_clone_sparse_matrix(fixture_class_parent: Type[Parent]):
     """Test clone with keyword parameter is scipy sparse matrix.
 
     This test is based on scikit-learn regression test to make sure clone
@@ -843,7 +866,7 @@ def test_clone_sparse_matrix(fixture_class_parent):
     np.testing.assert_array_equal(base_obj.c, new_base_obj2.c)
 
 
-def test_clone_nan(fixture_class_parent):
+def test_clone_nan(fixture_class_parent: Type[Parent]):
     """Test clone with keyword parameter is np.nan.
 
     This test is based on scikit-learn regression test to make sure clone
@@ -858,7 +881,7 @@ def test_clone_nan(fixture_class_parent):
     assert base_obj.c is new_base_obj2.c
 
 
-def test_clone_estimator_types(fixture_class_parent):
+def test_clone_estimator_types(fixture_class_parent: Type[Parent]):
     """Test clone works for parameters that are types rather than instances."""
     base_obj = fixture_class_parent(c=fixture_class_parent)
     new_base_obj = base_obj.clone()
@@ -866,7 +889,9 @@ def test_clone_estimator_types(fixture_class_parent):
     assert base_obj.c == new_base_obj.c
 
 
-def test_clone_class_rather_than_instance_raises_error(fixture_class_parent):
+def test_clone_class_rather_than_instance_raises_error(
+    fixture_class_parent: Type[Parent],
+):
     """Test clone raises expected error when cloning a class instead of an instance."""
     msg = "You should provide an instance of scikit-learn estimator"
     with pytest.raises(TypeError, match=msg):
@@ -874,7 +899,10 @@ def test_clone_class_rather_than_instance_raises_error(fixture_class_parent):
 
 
 # Tests of BaseObject pretty printing representation inspired by sklearn
-def test_baseobject_repr(fixture_class_parent, fixture_composition_dummy):
+def test_baseobject_repr(
+    fixture_class_parent: Type[Parent],
+    fixture_composition_dummy: Type[CompositionDummy],
+):
     """Test BaseObject repr works as expected."""
     # Simple test where all parameters are left at defaults
     # Should not see parameters and values in printed representation
@@ -893,12 +921,12 @@ def test_baseobject_repr(fixture_class_parent, fixture_composition_dummy):
     assert len(repr(long_base_obj_repr)) == 535
 
 
-def test_baseobject_str(fixture_class_parent_instance):
+def test_baseobject_str(fixture_class_parent_instance: Parent):
     """Test BaseObject string representation works."""
     str(fixture_class_parent_instance)
 
 
-def test_baseobject_repr_mimebundle_(fixture_class_parent_instance):
+def test_baseobject_repr_mimebundle_(fixture_class_parent_instance: Parent):
     """Test display configuration controls output."""
     # Checks the display configuration flag controls the json output
     with config_context(display="diagram"):
@@ -912,7 +940,7 @@ def test_baseobject_repr_mimebundle_(fixture_class_parent_instance):
         assert "text/html" not in output
 
 
-def test_repr_html_wraps(fixture_class_parent_instance):
+def test_repr_html_wraps(fixture_class_parent_instance: Parent):
     """Test display configuration flag controls the html output."""
     with config_context(display="diagram"):
         output = fixture_class_parent_instance._repr_html_()
@@ -925,20 +953,24 @@ def test_repr_html_wraps(fixture_class_parent_instance):
 
 
 # Test BaseObject's ability to generate test instances
-def test_get_test_params(fixture_class_parent_instance):
+def test_get_test_params(fixture_class_parent_instance: Parent):
     """Test get_test_params returns empty dictionary."""
     base_obj = fixture_class_parent_instance
     test_params = base_obj.get_test_params()
     assert isinstance(test_params, dict) and len(test_params) == 0
 
 
-def test_get_test_params_raises_error_when_params_required(fixture_required_param):
+def test_get_test_params_raises_error_when_params_required(
+    fixture_required_param: Type[RequiredParam],
+):
     """Test get_test_params raises an error when parameters are required."""
     with pytest.raises(ValueError):
         fixture_required_param(7).get_test_params()
 
 
-def test_create_test_instance(fixture_class_parent, fixture_class_parent_instance):
+def test_create_test_instance(
+    fixture_class_parent: Type[Parent], fixture_class_parent_instance: Parent
+):
     """Test first that create_test_instance logic works."""
     base_obj = fixture_class_parent.create_test_instance()
 
@@ -957,7 +989,7 @@ def test_create_test_instance(fixture_class_parent, fixture_class_parent_instanc
     assert hasattr(base_obj, "_tags_dynamic"), msg
 
 
-def test_create_test_instances_and_names(fixture_class_parent_instance):
+def test_create_test_instances_and_names(fixture_class_parent_instance: Parent):
     """Test that create_test_instances_and_names works."""
     base_objs, names = fixture_class_parent_instance.create_test_instances_and_names()
 
@@ -990,7 +1022,7 @@ def test_create_test_instances_and_names(fixture_class_parent_instance):
 
 # Tests _has_implementation_of interface
 def test_has_implementation_of(
-    fixture_class_parent_instance, fixture_class_child_instance
+    fixture_class_parent_instance: Parent, fixture_class_child_instance: Child
 ):
     """Test _has_implementation_of detects methods in class with overrides in mro."""
     # When the class overrides a parent classes method should return True
@@ -1014,33 +1046,184 @@ class ConfigTester(BaseObject):
         self.c = 84
 
 
-def test_set_get_config():
-    """Test logic behind get_config, set_config.
+class AnotherConfigTester(BaseObject):
+    _config = {"print_changed_only": False, "bar": "a"}
 
-    Raises
-    ------
-    AssertionError if logic behind get_config, set_config is incorrect, logic tested:
-        calling get_fitted_params on a non-composite fittable returns the fitted param
-        calling get_fitted_params on a composite returns all nested params
+    clsvar = 210
+
+    def __init__(self, a, b=42):
+        self.a = a
+        self.b = b
+        self.c = 84
+
+
+class ConfigExtensionInterfaceTester(BaseObject):
+    _config = {"print_changed_only": False, "bar": "a"}
+
+    clsvar = 210
+
+    def __init__(self, a, b=42):
+        self.a = a
+        self.b = b
+        self.c = 84
+
+    def __skbase_get_config__(self):
+        """Return get_config extension."""
+        return {"print_changed_only": True, "some_other_config": 70}
+
+
+def test_local_config_without_use_of_extension_interface():
+    """Test ``BaseObject().get_config`` and ``BaseObject().set_config``.
+
+    ``BaseObject.get_config()`` should return the global dict updated with any local
+    configs defined in ``BaseObject._config`` or set on the instance with
+    ``BaseObject().set_config()``.
     """
+    # Initially test that We can retrieve the local config with local configs
+    # as defined in BaseObject._config
+
+    # Case 1: local configs are not part of global config param names
     obj = ConfigTester(4242)
+    obj_config = obj.get_config()
+    current_global_config = get_config().copy()
+    expected_global_config = set(current_global_config.keys())
+    assert isinstance(obj_config, dict)
+    assert set(obj_config.keys()) == expected_global_config | {"foo_config", "bar"}
+    assert obj_config["foo_config"] == 42
+    assert obj_config["bar"] == "a"
+    for param_name in current_global_config:
+        assert obj_config[param_name] == current_global_config[param_name]
 
-    config_start = obj.get_config()
-    assert isinstance(config_start, dict)
-    assert set(config_start.keys()) == {"foo_config", "bar"}
-    assert config_start["foo_config"] == 42
-    assert config_start["bar"] == "a"
+    # Case 2: local configs overlap with (will override) global params
+    obj = AnotherConfigTester(4242)
+    obj_config = obj.get_config()
+    current_global_config = get_config().copy()
+    expected_global_config = set(current_global_config.keys())
+    assert isinstance(obj_config, dict)
+    assert set(obj_config.keys()) == expected_global_config | {"bar"}
+    assert obj_config["bar"] == "a"
+    # Should have overrided global config value which is set to True
+    assert obj_config["print_changed_only"] is False
+    for param_name in current_global_config:
+        if param_name != "print_changed_only":
+            assert obj_config[param_name] == current_global_config[param_name]
 
+    # Case 3: local configs are not part of global config param names and we also
+    # make use of dynamic BaseObject.set_config()
+    obj = ConfigTester(4242)
+    obj_config = obj.get_config()
+    current_global_config = get_config().copy()
+    expected_global_config = set(current_global_config.keys())
+
+    # Verify set config returns the original object
     setconfig_return = obj.set_config(foobar=126)
     assert obj is setconfig_return
 
     obj.set_config(**{"bar": "b"})
-    config_end = obj.get_config()
-    assert isinstance(config_end, dict)
-    assert set(config_end.keys()) == {"foo_config", "bar", "foobar"}
-    assert config_end["foo_config"] == 42
-    assert config_end["bar"] == "b"
-    assert config_end["foobar"] == 126
+    updated_obj_config = obj.get_config()
+    assert isinstance(updated_obj_config, dict)
+    assert set(updated_obj_config.keys()) == (
+        expected_global_config | {"foo_config", "bar", "foobar"}
+    )
+    assert updated_obj_config["foo_config"] == 42
+    assert updated_obj_config["bar"] == "b"
+    assert updated_obj_config["foobar"] == 126
+
+    # Case 4: local configs are not part of global config param names and we also
+    # make use of dynamic BaseObject.set_config() to update a config that is also
+    # part of global config
+    obj = ConfigTester(4242)
+    obj_config = obj.get_config()
+    current_global_config = get_config().copy()
+    expected_global_config = set(current_global_config.keys())
+
+    # Verify set config returns the original object
+    setconfig_return = obj.set_config(print_changed_only=False)
+    assert obj is setconfig_return
+
+    updated_obj_config = obj.get_config()
+    assert isinstance(updated_obj_config, dict)
+    assert set(updated_obj_config.keys()) == (
+        expected_global_config | {"foo_config", "bar"}
+    )
+    assert updated_obj_config["foo_config"] == 42
+    assert updated_obj_config["bar"] == "a"
+    assert updated_obj_config["print_changed_only"] is False
+    for param_name in current_global_config:
+        if param_name != "print_changed_only":
+            assert updated_obj_config[param_name] == current_global_config[param_name]
+
+    # Case 5: local configs overlap with (will override) global params
+    # Then the local config defined in AnotherConfigTester._config is overrode again
+    # by calling AnotherConfigTester().set_config()
+    obj = AnotherConfigTester(4242)
+    obj.set_config(print_changed_only=True)
+    obj_config = obj.get_config()
+    current_global_config = get_config().copy()
+    expected_global_config = set(current_global_config.keys())
+    assert isinstance(obj_config, dict)
+    assert set(obj_config.keys()) == expected_global_config | {"bar"}
+    assert obj_config["bar"] == "a"
+    # Should have overrided global config value which is set to True
+    assert obj_config["print_changed_only"] is True
+    for param_name in current_global_config:
+        if param_name != "print_changed_only":
+            assert obj_config[param_name] == current_global_config[param_name]
+
+
+def test_local_config_with_use_of_extension_interface():
+    """Test BaseObject local config interface when ``__skbase_get_config__`` defined.
+
+    BaseObject.get_config() should return the global dict updated in the following
+    order:
+
+        - Any config returned by ``BaseObject.__skbase_get_config__``.
+        - Any configs defined in ``BaseObject._config`` or set on the instance with
+          ``BaseObject().set_config()``.
+    """
+    current_global_config = get_config().copy()
+    obj = ConfigExtensionInterfaceTester(4242)
+    obj_config = obj.get_config()
+    assert "some_other_config" in obj_config
+    assert obj_config["print_changed_only"] is False
+
+    expected_global_config = set(current_global_config.keys())
+    assert isinstance(obj_config, dict)
+    assert set(obj_config.keys()) == expected_global_config | {
+        "some_other_config",
+        "bar",
+    }
+    assert obj_config["bar"] == "a"
+    # Should have overrided global config value which is set to True
+
+    for param_name in current_global_config:
+        if param_name != "print_changed_only":
+            assert obj_config[param_name] == current_global_config[param_name]
+
+    # Now lets verify we can override the config items only returned by
+    # __skbase_get_config__ extension interface
+    obj.set_config(some_other_config=22)
+    obj_config_updated = obj.get_config()
+    assert obj_config_updated["some_other_config"] == 22
+    for param_name in obj_config:
+        if param_name != "some_other_config":
+            assert obj_config_updated[param_name] == obj_config[param_name]
+
+
+def local_config_interface_does_not_affect_global_config_interface():
+    """Test that calls to instance config interface doesn't impact global config."""
+    from skbase.config import get_default_config, global_config
+
+    obj = AnotherConfigTester(4242)
+    _global_config_before = global_config.copy()
+    _default_config_before = get_default_config()
+    global_config_before = get_config().copy()
+    obj.set_config(print_changed_only=False, some_other_param=7)
+    global_config_after = get_config().copy()
+    assert global_config_before == global_config_after
+    assert "some_other_param" not in global_config_after
+    assert _global_config_before == global_config
+    assert _default_config_before == get_default_config()
 
 
 class FittableCompositionDummy(BaseEstimator):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skbase.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->




#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented. Remember to implement
unit tests and docstrings if your pull request commits code to the repository.
-->

This adds a global config interface. It allows the retrieval of the global config via ``get_config``, updating the global config via ``set_config``, finding out what ``skbase``'s default config is via ``get_default_config``, resetting the config to the default via ``reset_config``, and a config context manager via ``config_context``.

The PR also updates the local config interface's config retrieval (e.g., `BaseObject().get_config()`) so that it will retrieve the global config and then update it based on local config.

It also adds the ``__skbase_get_config__`` extension point. If it is defined on a descendent class and returns a dict, then the returned dict is used to update the global config. This is useful for downstream packages that use ``skbase`` to implement their own extension to ``skbase`` that reads their own package's global config.

Order of precedence is:

1. Retrieve a copy of the global config
2. If ``__skbase_get_config__`` is defined and returns a dict, then it is used to update the copy of the global config
3. Use local config interface to update the copy of the global config

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution requires a new dependency please indicate why it is necessary.
skbase seeks to mimimize dependencies to make it easy to use skbase in a variety
of environments and contexts.
-->

There is not any new dependencies added.

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development.
You can guide the reviews to focus on the parts that are ready for their comments.
We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

Does design make sense? Do tests cover any cases we can think of?

#### Any other comments?
<!--
Is there any other information the reviewer should know?
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've reviewed the project documentation on [contributing](https://skbase.readthedocs.io/en/latest/contribute.html)
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skbase/blob/main/.all-contributorsrc).
- [ ] The PR title starts with either [ENH], [CI/CD], [MNT], [DOC], or [BUG] indicating whether
  the PR topic is related to enhancement, CI/CD, maintenance, documentation, or a bug.

##### For code contributions
- [ ] Unit tests have been added covering code functionality
- [ ] Appropriate docstrings have been added (see [documentation standards](https://skbase.readthedocs.io/en/latest/contribute/development/developer_guide/creating_docs.html))
- [ ] New public functionality has been added to the API Reference


<!--
Thanks for contributing!
-->
