### PR TITLE
[DOC] fix odd author formatting on pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ name = "skbase"
 version = "0.3.0"
 description = "Base classes for sklearn-like parametric objects"
 authors = [
-    {name = "Franz Király", email = "f.kiraly@ucl.ac.uk"},
+    {name = "Franz Király"},
     {name = "Markus Löning"},
-    {name = "Ryan Kuhns", email = "rk.skbase@gmail.com"},
+    {name = "Ryan Kuhns"},
 ]
 maintainers = [
     {name = "Franz Kiraly", email = "f.kiraly@ucl.ac.uk"},


### PR DESCRIPTION
Fixes #151, by removing email information from all authors.
The information is still there in the maintainers entries, and the formatting issue is resolved.