### PR TITLE
[MNT] remove `pytest` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 requires-python = ">=3.7,<3.12"
 dependencies = [
-    "scikit-learn>=0.24.0,<1.3.0", "typing-extensions", "pytest"
+    "scikit-learn>=0.24.0,<1.3.0", "typing-extensions"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This removes `skbase`'s dependency on `pytest` which should not be required.

`pytest` is still required in the developer dependency set.
Rationale is minimizing dependencies.

E.g., `sktime` would otherwise incur a new core dependency, `pytest` - this violates the original intention of this being a pure refactor.