### PR TITLE
[MNT] remove `fail-fast` flag in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
     name: Test ${{ matrix.os }}-${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
-        fail-fast: true
+        fail-fast: false
         matrix:
           os: [ubuntu-latest, windows-latest, macOS-latest]
           python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']


### PR DESCRIPTION
This removes the `fail-fast` flag in CI, as the matrix runs concurrently and, usually, when one parallel task fails the next one is almost done already. Further, these take only few minutes to run, so should be no resource blocker.