### PR TITLE
[MNT] remove `scikit-learn` as a dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
     name: Test ${{ matrix.os }}-${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
-        fail-fast: true
+        fail-fast: false
         matrix:
           os: [ubuntu-latest, windows-latest, macOS-latest]
           python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,14 +35,13 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 requires-python = ">=3.7,<3.12"
-dependencies = [
-    "scikit-learn>=0.24.0,<1.3.0", "typing-extensions"
-]
+dependencies = ["typing-extensions"]
 
 [project.optional-dependencies]
 all_extras = ["numpy", "pandas"]
 
 dev = [
+    "scikit-learn>=0.24.0", 
     "pre-commit",
     "pytest",
     "pytest-cov"

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -101,7 +101,7 @@ class BaseObject(_FlagManager):
         self_params = self.get_params(deep=False)
         other_params = other.get_params(deep=False)
 
-        return deep_equals(self_params, other_params, return_msg=True)
+        return deep_equals(self_params, other_params)
 
     def reset(self):
         """Reset the object to a clean post-init state.
@@ -175,7 +175,7 @@ class BaseObject(_FlagManager):
         clone_attrs = {attr: getattr(self_clone, attr) for attr in self_params.keys()}
 
         # check equality of parameters post-clone and pre-clone
-        clone_attrs_valid, msg = deep_equals(self_params, clone_attrs)
+        clone_attrs_valid, msg = deep_equals(self_params, clone_attrs, return_msg=True)
         if not clone_attrs_valid:
             raise RuntimeError(
                 f"error in {self}.clone, __init__ must write all arguments "

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -59,9 +59,6 @@ from collections import defaultdict
 from copy import deepcopy
 from typing import List
 
-from sklearn import clone
-from sklearn.base import BaseEstimator as _BaseEstimator
-
 from skbase._exceptions import NotFittedError
 from skbase.base._pretty_printing._object_html_repr import _object_html_repr
 from skbase.base._tagmanager import _FlagManager
@@ -70,7 +67,7 @@ __author__: List[str] = ["mloning", "RNKuhns", "fkiraly"]
 __all__: List[str] = ["BaseEstimator", "BaseObject"]
 
 
-class BaseObject(_FlagManager, _BaseEstimator):
+class BaseObject(_FlagManager):
     """Base class for parametric objects with sktime style tag interface.
 
     Extends scikit-learn's BaseEstimator to include sktime style interface for tags.
@@ -147,12 +144,8 @@ class BaseObject(_FlagManager, _BaseEstimator):
 
         A clone is a different object without shared references, in post-init state.
         This function is equivalent to returning sklearn.clone of self.
-
-        Notes
-        -----
-        Also equal in value to `type(self)(**self.get_params(deep=False))`.
         """
-        return clone(self)
+        return type(self)(**self.get_params(deep=False))
 
     @classmethod
     def _get_init_signature(cls):

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -101,7 +101,7 @@ class BaseObject(_FlagManager):
         self_params = self.get_params(deep=False)
         other_params = other.get_params(deep=False)
 
-        return deep_equals(self_params, other_params)
+        return deep_equals(self_params, other_params, return_msg=True)
 
     def reset(self):
         """Reset the object to a clean post-init state.

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -158,7 +158,7 @@ class BaseObject(_FlagManager):
         self_clone = type(self)(**self_params)
 
         # if checking the clone is turned off, return now
-        if not self.get_config("check_clone"):
+        if not self.get_config()["check_clone"]:
             return self_clone
 
         from skbase.testing.utils.deep_equals import deep_equals

--- a/skbase/testing/test_all_objects.py
+++ b/skbase/testing/test_all_objects.py
@@ -13,15 +13,13 @@ from typing import List
 import joblib
 import numpy as np
 import pytest
-from sklearn.utils.estimator_checks import (
-    check_get_params_invariance as _check_get_params_invariance,
-)
 
 from skbase.base import BaseObject
 from skbase.lookup import all_objects
 from skbase.testing.utils._conditional_fixtures import (
     create_conditional_fixtures_and_names,
 )
+from skbase.testing.utils._dependencies import _check_soft_dependencies
 from skbase.testing.utils.deep_equals import deep_equals
 from skbase.testing.utils.inspect import _get_args
 
@@ -662,8 +660,16 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         assert not hasattr(object_instance, "test__attr")
         object_instance.test__attr = 42
 
+    @pytest.mark.skipif(
+        not _check_soft_dependencies("sklearn", severity="none"),
+        reason="skip test if sklearn is not available",
+    )  # sklearn is part of the dev dependency set, test should be executed with that
     def test_get_params(self, object_instance):
-        """Check that get_params works correctly."""
+        """Check that get_params works correctly, against sklearn interface."""
+        from sklearn.utils.estimator_checks import (
+            check_get_params_invariance as _check_get_params_invariance,
+        )
+
         params = object_instance.get_params()
         assert isinstance(params, dict)
         _check_get_params_invariance(

--- a/skbase/testing/test_all_objects.py
+++ b/skbase/testing/test_all_objects.py
@@ -803,7 +803,7 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
             if param.name not in required_params and param.name not in test_params
         ]
 
-        ALLOWED_PARAM_TYPES = [
+        allowed_param_types = [
             str,
             int,
             float,
@@ -816,7 +816,7 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         if _check_soft_dependencies("joblib", severity="none"):
             from joblib import Memory
 
-            ALLOWED_PARAM_TYPES += [Memory]
+            allowed_param_types += [Memory]
 
         for param in init_params:
             assert param.default != param.empty, (
@@ -827,7 +827,7 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
             if type(param.default) is type:
                 assert param.default in [np.float64, np.int64]
             else:
-                assert type(param.default) in ALLOWED_PARAM_TYPES
+                assert type(param.default) in allowed_param_types
 
             param_value = params[param.name]
             if isinstance(param_value, np.ndarray):

--- a/skbase/testing/test_all_objects.py
+++ b/skbase/testing/test_all_objects.py
@@ -10,7 +10,6 @@ from copy import deepcopy
 from inspect import getfullargspec, isclass, signature
 from typing import List
 
-import joblib
 import numpy as np
 import pytest
 
@@ -804,6 +803,21 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
             if param.name not in required_params and param.name not in test_params
         ]
 
+        ALLOWED_PARAM_TYPES = [
+            str,
+            int,
+            float,
+            bool,
+            tuple,
+            type(None),
+            np.float64,
+            types.FunctionType,
+        ]
+        if _check_soft_dependencies("joblib", severity="none"):
+            from joblib import Memory
+
+            ALLOWED_PARAM_TYPES += [Memory]
+
         for param in init_params:
             assert param.default != param.empty, (
                 "parameter `%s` for %s has no default value and is not "
@@ -813,17 +827,7 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
             if type(param.default) is type:
                 assert param.default in [np.float64, np.int64]
             else:
-                assert type(param.default) in [
-                    str,
-                    int,
-                    float,
-                    bool,
-                    tuple,
-                    type(None),
-                    np.float64,
-                    types.FunctionType,
-                    joblib.Memory,
-                ]
+                assert type(param.default) in ALLOWED_PARAM_TYPES
 
             param_value = params[param.name]
             if isinstance(param_value, np.ndarray):

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -142,9 +142,7 @@ class ModifyParam(BaseObject):
     """A non-conforming BaseObject that modifies parameters in init."""
 
     def __init__(self, a=7):
-        self.a = a
-        if isinstance(a, list):
-            a += [42]
+        self.a = deepcopy(a)
         super().__init__()
 
 
@@ -823,9 +821,13 @@ def test_clone_raises_error_for_nonconforming_objects(
     with pytest.raises(RuntimeError):
         varg_obj.clone()
 
-    obj_that_modifies = fixture_modify_param(a=[0])
-    with pytest.raises(RuntimeError):
-        obj_that_modifies.clone()
+    # fkiraly note: I don't think this class violates the contract,
+    # as equality is defined as via deepcopy
+    # leaving the code here for reference and potential discussion
+    #
+    # obj_that_modifies = fixture_modify_param(a=[0])
+    # with pytest.raises(RuntimeError):
+    #     obj_that_modifies.clone()
 
 
 @pytest.mark.skipif(

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -139,7 +139,7 @@ class Buggy(BaseObject):
 
 
 class ModifyParam(BaseObject):
-    """A non-conforming BaseObject that modifyies parameters in init."""
+    """A non-conforming BaseObject that modifies parameters in init."""
 
     def __init__(self, a=7):
         self.a = deepcopy(a)

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -142,6 +142,7 @@ class ModifyParam(BaseObject):
     """A non-conforming BaseObject that modifies parameters in init."""
 
     def __init__(self, a=7):
+        self.a = a
         if isinstance(a, list):
             a += [42]
         super().__init__()

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -142,7 +142,8 @@ class ModifyParam(BaseObject):
     """A non-conforming BaseObject that modifies parameters in init."""
 
     def __init__(self, a=7):
-        self.a = deepcopy(a)
+        if isinstance(a, list):
+            a += [42]
         super().__init__()
 
 

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -75,12 +75,10 @@ import numpy as np
 import pytest
 import scipy.sparse as sp
 
-# TODO: Update with import of skbase clone function once implemented
-from sklearn.base import clone
-
 from skbase.base import BaseEstimator, BaseObject
 from skbase.tests.conftest import Child, Parent
 from skbase.tests.mock_package.test_mock_package import CompositionDummy
+from skbase.testing.utils._dependencies import _check_soft_dependencies
 
 
 # TODO: Determine if we need to add sklearn style test of
@@ -828,8 +826,14 @@ def test_clone_raises_error_for_nonconforming_objects(
         obj_that_modifies.clone()
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("sklearn", severity="none"),
+    reason="skip test if sklearn is not available",
+)  # sklearn is part of the dev dependency set, test should be executed with that
 def test_clone_param_is_none(fixture_class_parent: Type[Parent]):
     """Test clone with keyword parameter set to None."""
+    from sklearn.base import clone
+
     base_obj = fixture_class_parent(c=None)
     new_base_obj = clone(base_obj)
     new_base_obj2 = base_obj.clone()
@@ -837,12 +841,18 @@ def test_clone_param_is_none(fixture_class_parent: Type[Parent]):
     assert base_obj.c is new_base_obj2.c
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("sklearn", severity="none"),
+    reason="skip test if sklearn is not available",
+)  # sklearn is part of the dev dependency set, test should be executed with that
 def test_clone_empty_array(fixture_class_parent: Type[Parent]):
     """Test clone with keyword parameter is scipy sparse matrix.
 
     This test is based on scikit-learn regression test to make sure clone
     works with default parameter set to scipy sparse matrix.
     """
+    from sklearn.base import clone
+
     # Regression test for cloning estimators with empty arrays
     base_obj = fixture_class_parent(c=np.array([]))
     new_base_obj = clone(base_obj)
@@ -851,12 +861,18 @@ def test_clone_empty_array(fixture_class_parent: Type[Parent]):
     np.testing.assert_array_equal(base_obj.c, new_base_obj2.c)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("sklearn", severity="none"),
+    reason="skip test if sklearn is not available",
+)  # sklearn is part of the dev dependency set, test should be executed with that
 def test_clone_sparse_matrix(fixture_class_parent: Type[Parent]):
     """Test clone with keyword parameter is scipy sparse matrix.
 
     This test is based on scikit-learn regression test to make sure clone
     works with default parameter set to scipy sparse matrix.
     """
+    from sklearn.base import clone
+
     base_obj = fixture_class_parent(c=sp.csr_matrix(np.array([[0]])))
     new_base_obj = clone(base_obj)
     new_base_obj2 = base_obj.clone()
@@ -864,12 +880,18 @@ def test_clone_sparse_matrix(fixture_class_parent: Type[Parent]):
     np.testing.assert_array_equal(base_obj.c, new_base_obj2.c)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("sklearn", severity="none"),
+    reason="skip test if sklearn is not available",
+)  # sklearn is part of the dev dependency set, test should be executed with that
 def test_clone_nan(fixture_class_parent: Type[Parent]):
     """Test clone with keyword parameter is np.nan.
 
     This test is based on scikit-learn regression test to make sure clone
     works with default parameter set to np.nan.
     """
+    from sklearn.base import clone
+
     # Regression test for cloning estimators with default parameter as np.nan
     base_obj = fixture_class_parent(c=np.nan)
     new_base_obj = clone(base_obj)
@@ -887,10 +909,16 @@ def test_clone_estimator_types(fixture_class_parent: Type[Parent]):
     assert base_obj.c == new_base_obj.c
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("sklearn", severity="none"),
+    reason="skip test if sklearn is not available",
+)  # sklearn is part of the dev dependency set, test should be executed with that
 def test_clone_class_rather_than_instance_raises_error(
     fixture_class_parent: Type[Parent],
 ):
     """Test clone raises expected error when cloning a class instead of an instance."""
+    from sklearn.base import clone
+
     msg = "You should provide an instance of scikit-learn estimator"
     with pytest.raises(TypeError, match=msg):
         clone(fixture_class_parent)

--- a/skbase/tests/test_meta.py
+++ b/skbase/tests/test_meta.py
@@ -78,7 +78,7 @@ def test_basemetaestimator_inheritance(fixture_metaestimator_instance):
     ), "`BaseMetaEstimator` not correctly subclassing `BaseEstimator` and `BaseObject`."
 
     # Verify expected MRO inherittence order
-    assert BaseMetaEstimator.__mro__[:-3] == (
+    assert BaseMetaEstimator.__mro__[:-2] == (
         BaseMetaEstimator,
         _MetaObjectMixin,
         _MetaTagLogicMixin,


### PR DESCRIPTION
This PR removes `scikit-learn` as a dependency, including the remaining loci of coupling.

* in `BaseObject`, `scikit-learn` was still used in `clone`. This has been replaced with a constructor call, and checks that the tests expect. A config has been added that allows to skip these checks.
* in various tests, `scikit-learn` `clone` was still imported, this is useful for checking compatibility. Here, the imports have been isolated inside the tests, so the import is executed only in CI when the `dev` dependency set is installed. In a case where not, the tests are not executed.
* `BaseObject` was still inheriting from `sklearn` `BaseEstimator`,  but this should be unnecessary as all has been overridden now. This was removed, and tests for MRO adjusted.
* `joblib` has been imported in the tests, in a check for parameter validity. Now, `joblib` is imported, and the check executed only if `joblib` is present in the environment.