### PR TITLE
[MNT] add `sklearn` to `test` dependency set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ test = [
     "numpy",
     "scipy",
     "pandas",
+    "scikit-learn>=0.24.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
This explicitly adds `sklearn` to `tests` dependency set, as it is required in some tests for compatibility.