### PR TITLE
[MNT] resolve dependency conflict in `docs` requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ docs = [
     "pydata-sphinx-theme",
     "sphinx_issues==1.2.0",
     "sphinx-gallery==0.6.0",
+    "sphinx-panels",
     "sphinx-design==0.3.0",
     "sphinx==4.1.1",
     "tabulate",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,12 +72,11 @@ docs = [
     "nbsphinx>=0.8.6",
     "numpydoc",
     "pydata-sphinx-theme",
-    "sphinx-copybutton",
-    "sphinx-issues",
-    "sphinx-gallery",
-    "sphinx-panels",
-    "sphinx-design",
-    "sphinx",
+    "sphinx_issues==1.2.0",
+    "sphinx-gallery==0.6.0",
+    "sphinx-design==0.3.0",
+    "sphinx==4.1.1",
+    "tabulate",
 ]
 
 test = [


### PR DESCRIPTION
the `skbase` documentation currently does not build due to conflicting requirements in the `docs` dependency set.

The error is this:
```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
sphinx-rtd-theme 1.2.0 requires docutils<0.19, but you have docutils 0.19 which is incompatible.
```

This PR resolves the problem by copy-pasting the dependency set from `sktime`.