### PR TITLE
[DOC] fix some broken doc links, linting

### DIFF
--- a/docs/source/user_documentation/changelog.rst
+++ b/docs/source/user_documentation/changelog.rst
@@ -6,11 +6,11 @@ All notable changes to this project beggining with version 0.1.0 will be
 documented in this file. The format is based on
 `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_ and we adhere
 to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_. The source
-code for all `releases <https://github.com/sktime/baseobject/releases>`_
+code for all `releases <https://github.com/sktime/skbase/releases>`_
 is available on GitHub.
 
 You can also subscribe to ``skbase``'s
-`PyPi release <https://libraries.io/pypi/baseobject>`_.
+`PyPi release <https://libraries.io/pypi/scikit-base>`_.
 
 For planned changes and upcoming releases, see our :ref:`roadmap`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "skbase"
+name = "scikit-base"
 version = "0.4.2"
 description = "Base classes for sklearn-like parametric objects"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "scikit-base"
+name = "skbase"
 version = "0.4.2"
 description = "Base classes for sklearn-like parametric objects"
 authors = [

--- a/skbase/validate/_types.py
+++ b/skbase/validate/_types.py
@@ -213,7 +213,7 @@ def is_sequence(
         element_type_ = _convert_scalar_seq_type_input_to_tuple(
             element_type, input_name="element_type"
         )
-        element_types_okay = all([isinstance(e, element_type_) for e in input_seq])
+        element_types_okay = all(isinstance(e, element_type_) for e in input_seq)
         if not element_types_okay:
             is_valid_sequence = False
 


### PR DESCRIPTION
This fixes some outdated pointers to the old repository name and the old pypi name (both `baseobject`), on the changelog documentation page.

Also fixes a linting complaint by the precommit.