### PR TITLE
[ENH] turn off check in `BaseObject.clone`

### DIFF
--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -76,7 +76,7 @@ class BaseObject(_FlagManager):
     _config = {
         "display": "diagram",
         "print_changed_only": True,
-        "check_clone": True,  # whether to execute validity checks in clone
+        "check_clone": False,  # whether to execute validity checks in clone
     }
 
     def __init__(self):

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -813,11 +813,13 @@ def test_clone_raises_error_for_nonconforming_objects(
 ):
     """Test that clone raises an error on nonconforming BaseObjects."""
     buggy = fixture_buggy()
+    buggy.set_config(**{"check_clone": True})
     buggy.a = 2
     with pytest.raises(RuntimeError):
         buggy.clone()
 
     varg_obj = fixture_invalid_init(a=7)
+    varg_obj.set_config(**{"check_clone": True})
     with pytest.raises(RuntimeError):
         varg_obj.clone()
 
@@ -826,6 +828,7 @@ def test_clone_raises_error_for_nonconforming_objects(
     # leaving the code here for reference and potential discussion
     #
     # obj_that_modifies = fixture_modify_param(a=[0])
+    # obj_that_modifies.set_config(**{"check_clone": True})
     # with pytest.raises(RuntimeError):
     #     obj_that_modifies.clone()
 


### PR DESCRIPTION
This PR turns off the check in `BaseObject.clone`, which unintentionally couples `clone` to `pytest`, via import of `deep_equals` that imports `pytest` by accident (through `__init__`).

This can be done without deprecation, ahead of a refactor that moves `deep_equals` out of the `testing` module.

Fast fix for https://github.com/sktime/skbase/issues/177 but does not address it finally (if `check_clone` config is `True`, the bug still occurs)