### PR TITLE
[MNT] test for isolation of developer dependencies, and basic `pytest`-less test for `BaseObject`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           python -m pip install .
 
-      - name: Rune the pytest-free tests
+      - name: Run pytest-free tests
         run: |
           python skbase/_nopytest_tests.py
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,26 @@ jobs:
         run: build_tools/fail_on_missing_init_files.sh
         shell: bash
 
+  test-nodevdeps:
+    needs: code-quality
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      - name: Install skbase and dependencies
+        run: |
+          python -m pip install .
+
+      - name: Rune the pytest-free tests
+        run: |
+          python skbase/_nopytest_tests.py
+
   run-tests:
     needs: code-quality
     name: Test ${{ matrix.os }}-${{ matrix.python-version }}

--- a/skbase/_nopytest_tests.py
+++ b/skbase/_nopytest_tests.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""Tests to run without pytest, to check pytest isolation."""
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+
+from skbase.base import BaseObject
+from skbase.lookup import all_objects
+
+MODULES_TO_IGNORE = ("tests", "dependencies", "all")
+
+# all_objectscrawls all modules excepting pytest test files
+# if it encounters an unisolated import, it will throw an exception
+results = all_objects()
+
+# try to run all methods of BaseObject without arguments
+# very basic test, but needs to run without pytest
+METHODS = [
+    "clone",
+    "get_params",
+    "reset",
+    "get_param_names",
+    "get_param_defaults",
+    "get_params",
+    "get_class_tags",
+    "get_tags",
+    "get_config",
+    "get_test_params",
+    "create_test_instance",
+    "create_test_instances_and_names",
+    "is_composite",
+]
+
+mybo = BaseObject()
+for method in METHODS:
+    getattr(mybo, method)

--- a/skbase/_nopytest_tests.py
+++ b/skbase/_nopytest_tests.py
@@ -9,7 +9,7 @@ MODULES_TO_IGNORE = ("tests", "dependencies", "all")
 
 # all_objectscrawls all modules excepting pytest test files
 # if it encounters an unisolated import, it will throw an exception
-results = all_objects()
+results = all_objects(modules_to_ignore=MODULES_TO_IGNORE)
 
 # try to run all methods of BaseObject without arguments
 # very basic test, but needs to run without pytest

--- a/skbase/_nopytest_tests.py
+++ b/skbase/_nopytest_tests.py
@@ -5,7 +5,7 @@
 from skbase.base import BaseObject
 from skbase.lookup import all_objects
 
-MODULES_TO_IGNORE = ("tests", "dependencies", "all")
+MODULES_TO_IGNORE = ("tests", "testing", "dependencies", "all")
 
 # all_objectscrawls all modules excepting pytest test files
 # if it encounters an unisolated import, it will throw an exception

--- a/skbase/tests/conftest.py
+++ b/skbase/tests/conftest.py
@@ -19,6 +19,7 @@ SKBASE_BASE_CLASSES = (BaseObject, BaseEstimator)
 SKBASE_MODULES = (
     "skbase",
     "skbase._exceptions",
+    "skbase._nopytest_tests",
     "skbase.base",
     "skbase.base._base",
     "skbase.base._meta",


### PR DESCRIPTION
This adds basic tests to ensure isolation from developer dependencies including `pytest` outside of test modules, and adds a basic `pytest`-less test for `BaseObject`.

The approach is as follows:

* addition of a new GHA job
* only `skbase` plain is installed, no `dev` dependencies
* a test file `_nopytest_tests` is added, which can contain `pytest`-free checks
* `all_objects` plain is executed. As this crawls all modules (except tests and a few others), it will spot unisolated developer dependency imports
* parameterless methods of `BaseObject` are executed on an instance. This ensures those methods are isolated, and it would also catche the issue with `clone` described here: https://github.com/sktime/skbase/issues/177