### PR TITLE
[MNT] address deprecation of `load_module`

### DIFF
--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -297,7 +297,12 @@ def _import_module(
         if isinstance(module, str):
             imported_mod = importlib.import_module(module)
         elif isinstance(module, importlib.machinery.SourceFileLoader):
-            imported_mod = module.load_module()
+            spec = importlib.machinery.ModuleSpec(
+                name=module.name,
+                loader=module,
+                origin=module.path,
+            )
+            imported_mod = importlib.util.module_from_spec(spec)
         exc = None
     except Exception as e:
         # we store the exception so we can restore the stdout fisrt

--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -298,6 +298,7 @@ def _import_module(
             imported_mod = importlib.import_module(module)
         elif isinstance(module, importlib.machinery.SourceFileLoader):
             spec = importlib.util.spec_from_loader(module.name, module)
+            spec.origin = module.path
             imported_mod = importlib.util.module_from_spec(spec)
         exc = None
     except Exception as e:

--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -297,11 +297,7 @@ def _import_module(
         if isinstance(module, str):
             imported_mod = importlib.import_module(module)
         elif isinstance(module, importlib.machinery.SourceFileLoader):
-            spec = importlib.machinery.ModuleSpec(
-                name=module.name,
-                loader=module,
-                origin=module.path,
-            )
+            spec = importlib.util.spec_from_loader(module.name, module)
             imported_mod = importlib.util.module_from_spec(spec)
         exc = None
     except Exception as e:

--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -297,7 +297,7 @@ def _import_module(
         if isinstance(module, str):
             imported_mod = importlib.import_module(module)
         elif isinstance(module, importlib.machinery.SourceFileLoader):
-            spec = importlib.spec_from_file_location(module.name, module.path)
+            spec = importlib.util.spec_from_file_location(module.name, module.path)
             imported_mod = importlib.util.module_from_spec(spec)
 
             loader = spec.loader

--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -291,10 +291,10 @@ def _import_module(
     elif isinstance(module, importlib.machinery.SourceFileLoader):
         if suppress_import_stdout:
             sys.stdout = io.StringIO()
-            imported_mod = module.load_module()
+            imported_mod = module.exec_module()
             sys.stdout = sys.__stdout__
         else:
-            imported_mod = module.load_module()
+            imported_mod = module.exec_module()
     else:
         raise ValueError(
             "`module` should be string module name or instance of "

--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -297,9 +297,11 @@ def _import_module(
         if isinstance(module, str):
             imported_mod = importlib.import_module(module)
         elif isinstance(module, importlib.machinery.SourceFileLoader):
-            spec = importlib.util.spec_from_loader(module.name, module)
-            spec.origin = module.path
+            spec = importlib.spec_from_file_location(module.name, module.path)
             imported_mod = importlib.util.module_from_spec(spec)
+
+            loader = spec.loader
+            loader.exec_module(imported_mod)
         exc = None
     except Exception as e:
         # we store the exception so we can restore the stdout fisrt


### PR DESCRIPTION
`load_module` is deprecated and will be replaced by `exec_module` in python 3.12, this PR addresses that.

The fix is highly nontrivial - the crucial line was
`imported_mod = module.load_module()` for a `module: SourceFileLoader`,

which had to be replaced by the equivalent four (!) lines

```python
spec = importlib.util.spec_from_file_location(module.name, module.path)
imported_mod = importlib.util.module_from_spec(spec)

# these two are also crucial due to the side effects
loader = spec.loader
loader.exec_module(imported_mod)
```

The deprecation message raised by `load_module` is highly unhelpful, and I had to reverse engineer this from a very helpful PR in `nox`, https://github.com/wntrblm/nox/pull/498