### PR TITLE
[DOC] update project metadata, point governance to `sktime`, update `__init__` info 

### DIFF
--- a/docs/source/about/governance.rst
+++ b/docs/source/about/governance.rst
@@ -4,6 +4,15 @@
 Governance
 ==========
 
+.. topic:: This project is part of the ``sktime`` project.
+
+    The ``skbase`` repository and community is currently to be considered part of
+    ``sktime``, and not a separate entity. It is maintained by the ``sktime`` team.
+    It is THEREFORE subject to rules and provisions of ``sktime``,
+    see `sktime governance <http://www.sktime.net/en/latest/about/governance.html>`_.
+    The below are draft documents for a potentially later stage, copied from ``sktime``.
+    In case of discrepancy, ``sktime`` documents apply.
+
 Overview
 ========
 

--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -4,47 +4,8 @@
 Development Team
 ================
 
-Information about the rights and responsibilities associated with each role
-are described in ``skbase``'s :ref:`governance` document. A list of
-all contributors can be found under the `contributors <contributors.md>`_
-section.
+This package is currently maintained by the ``sktime`` community, see
+`sktime team <http://www.sktime.net/en/latest/about/team.html>`_.
 
-Community Council
-=================
-
-.. list-table::
-   :header-rows: 1
-
-   * - Name
-     - GitHub ID
-   * - Franz Kiraly
-     - :user:`fkiraly`
-   * - Ryan Kuhns
-     - :user:`rnkuhns`
-
-Code of Conduct Committee
-=========================
-
-.. list-table::
-   :header-rows: 1
-
-   * - Name
-     - GitHub ID
-   * - Franz Kiraly
-     - :user:`fkiraly`
-
-Core Developers
-===============
-
-.. list-table::
-   :header-rows: 1
-
-   * - Name
-     - GitHub ID
-   * - Franz Kiraly
-     - :user:`fkiraly`
-   * - Ryan Kuhns
-     - :user:`rnkuhns`
-
-Former Core Developers (inactive)
-=================================
+This project is currently to be considered part of ``sktime``,
+and not a separate entity.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,11 @@ name = "skbase"
 version = "0.4.5"
 description = "Base classes for sklearn-like parametric objects"
 authors = [
-    {name = "Franz Király"},
-    {name = "Markus Löning"},
-    {name = "Ryan Kuhns"},
+    {name = "sktime developers", email = "sktime.toolbox@gmail.com"},
 ]
 maintainers = [
-    {name = "Franz Kiraly", email = "f.kiraly@ucl.ac.uk"},
-    {name = "Ryan Kuhns", email = "rk.skbase@gmail.com"},
+    {name = "sktime developers", email = "sktime.toolbox@gmail.com"},
+    {name = "Franz Király"},
 ]
 readme = "README.md"
 keywords = [

--- a/skbase/__init__.py
+++ b/skbase/__init__.py
@@ -8,7 +8,7 @@ sktime design principles in your project.
 """
 from typing import List
 
-__version__: str = "0.4.0"
+__version__: str = "0.4.5"
 
-__author__: List[str] = ["mloning", "RNKuhns", "fkiraly"]
+__author__: List[str] = ["fkiraly", "RNKuhns", "mloning"]
 __all__: List[str] = []


### PR DESCRIPTION
This PR updates project information in the docs and `__init__`:

* the package now points to `sktime`, as being part of `sktime` and being maintained by the `sktime` team, in relevant places - sphinx docs (governance, team), and `pyproject.toml`
* in particular, it is no longer a separate entity per the docs, as the single active CC member (of `skbase`) I don't think that makes sense - especially since it receives most occasional fixes from `sktime` maintainers
* the version string in the package `__init__` was not up-to-date with the `pyproject.toml`, this is fixed.

Fixes #189 in passing (I think all instances are removed or superseded by this)