### PR TITLE
&hazrulakmal [BUG] fix `clone` for nested `sklearn` estimators

### DIFF
--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -1211,7 +1211,7 @@ class BaseEstimator(BaseObject):
         estimator_type = type(estimator)
         # XXX: not handling dictionaries
         if estimator_type in (list, tuple, set, frozenset):
-            return estimator_type([clone(e, safe=safe) for e in estimator])
+            return estimator_type([self._clone(e, safe=safe) for e in estimator])
         elif not hasattr(estimator, "get_params") or isinstance(estimator, type):
             if not safe:
                 return deepcopy(estimator)
@@ -1233,7 +1233,7 @@ class BaseEstimator(BaseObject):
         klass = estimator.__class__
         new_object_params = estimator.get_params(deep=False)
         for name, param in new_object_params.items():
-            new_object_params[name] = clone(param, safe=False)
+            new_object_params[name] = self._clone(param, safe=False)
         new_object = klass(**new_object_params)
         params_set = new_object.get_params(deep=False)
 

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -155,7 +155,7 @@ class BaseObject(_FlagManager):
         If successful, equal in value to ``type(self)(**self.get_params(deep=False))``.
         """
         self_params = self.get_params(deep=False)
-        self_clone = type(self)(**self_params)
+        self_clone = clone(self)
 
         # if checking the clone is turned off, return now
         if not self.get_config()["check_clone"]:
@@ -1176,3 +1176,75 @@ class BaseEstimator(BaseObject):
             fitted parameters, keyed by names of fitted parameter
         """
         return self._get_fitted_params_default()
+
+
+# copied from sklearn
+def clone(estimator, *, safe=True):
+    """Construct a new unfitted estimator with the same parameters.
+
+    Clone does a deep copy of the model in an estimator
+    without actually copying attached data. It returns a new estimator
+    with the same parameters that has not been fitted on any data.
+
+    Parameters
+    ----------
+    estimator : {list, tuple, set} of estimator instance or a single \
+            estimator instance
+        The estimator or group of estimators to be cloned.
+    safe : bool, default=True
+        If safe is False, clone will fall back to a deep copy on objects
+        that are not estimators.
+
+    Returns
+    -------
+    estimator : object
+        The deep copy of the input, an estimator if input is an estimator.
+
+    Notes
+    -----
+    If the estimator's `random_state` parameter is an integer (or if the
+    estimator doesn't have a `random_state` parameter), an *exact clone* is
+    returned: the clone and the original estimator will give the exact same
+    results. Otherwise, *statistical clone* is returned: the clone might
+    return different results from the original estimator. More details can be
+    found in :ref:`randomness`.
+    """
+    estimator_type = type(estimator)
+    # XXX: not handling dictionaries
+    if estimator_type in (list, tuple, set, frozenset):
+        return estimator_type([clone(e, safe=safe) for e in estimator])
+    elif not hasattr(estimator, "get_params") or isinstance(estimator, type):
+        if not safe:
+            return deepcopy(estimator)
+        else:
+            if isinstance(estimator, type):
+                raise TypeError(
+                    "Cannot clone object. "
+                    + "You should provide an instance of "
+                    + "scikit-learn estimator instead of a class."
+                )
+            else:
+                raise TypeError(
+                    "Cannot clone object '%s' (type %s): "
+                    "it does not seem to be a scikit-learn "
+                    "estimator as it does not implement a "
+                    "'get_params' method." % (repr(estimator), type(estimator))
+                )
+
+    klass = estimator.__class__
+    new_object_params = estimator.get_params(deep=False)
+    for name, param in new_object_params.items():
+        new_object_params[name] = clone(param, safe=False)
+    new_object = klass(**new_object_params)
+    params_set = new_object.get_params(deep=False)
+
+    # quick sanity check of the parameters of the clone
+    for name in new_object_params:
+        param1 = new_object_params[name]
+        param2 = params_set[name]
+        if param1 is not param2:
+            raise RuntimeError(
+                "Cannot clone object %s, as the constructor "
+                "either does not set or modifies parameter %s" % (estimator, name)
+            )
+    return new_object

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -185,6 +185,77 @@ class BaseObject(_FlagManager):
 
         return self_clone
 
+    # copied from sklearn
+    def _clone(self, estimator, *, safe=True):
+        """Construct a new unfitted estimator with the same parameters.
+
+        Clone does a deep copy of the model in an estimator
+        without actually copying attached data. It returns a new estimator
+        with the same parameters that has not been fitted on any data.
+
+        Parameters
+        ----------
+        estimator : {list, tuple, set} of estimator instance or a single \
+                estimator instance
+            The estimator or group of estimators to be cloned.
+        safe : bool, default=True
+            If safe is False, clone will fall back to a deep copy on objects
+            that are not estimators.
+
+        Returns
+        -------
+        estimator : object
+            The deep copy of the input, an estimator if input is an estimator.
+
+        Notes
+        -----
+        If the estimator's `random_state` parameter is an integer (or if the
+        estimator doesn't have a `random_state` parameter), an *exact clone* is
+        returned: the clone and the original estimator will give the exact same
+        results. Otherwise, *statistical clone* is returned: the clone might
+        return different results from the original estimator. More details can be
+        found in :ref:`randomness`.
+        """
+        estimator_type = type(estimator)
+        # XXX: not handling dictionaries
+        if estimator_type in (list, tuple, set, frozenset):
+            return estimator_type([self._clone(e, safe=safe) for e in estimator])
+        elif not hasattr(estimator, "get_params") or isinstance(estimator, type):
+            if not safe:
+                return deepcopy(estimator)
+            else:
+                if isinstance(estimator, type):
+                    raise TypeError(
+                        "Cannot clone object. "
+                        + "You should provide an instance of "
+                        + "scikit-learn estimator instead of a class."
+                    )
+                else:
+                    raise TypeError(
+                        "Cannot clone object '%s' (type %s): "
+                        "it does not seem to be a scikit-learn "
+                        "estimator as it does not implement a "
+                        "'get_params' method." % (repr(estimator), type(estimator))
+                    )
+
+        klass = estimator.__class__
+        new_object_params = estimator.get_params(deep=False)
+        for name, param in new_object_params.items():
+            new_object_params[name] = self._clone(param, safe=False)
+        new_object = klass(**new_object_params)
+        params_set = new_object.get_params(deep=False)
+
+        # quick sanity check of the parameters of the clone
+        for name in new_object_params:
+            param1 = new_object_params[name]
+            param2 = params_set[name]
+            if param1 is not param2:
+                raise RuntimeError(
+                    "Cannot clone object %s, as the constructor "
+                    "either does not set or modifies parameter %s" % (estimator, name)
+                )
+        return new_object
+
     @classmethod
     def _get_init_signature(cls):
         """Get class init sigature.
@@ -1176,74 +1247,3 @@ class BaseEstimator(BaseObject):
             fitted parameters, keyed by names of fitted parameter
         """
         return self._get_fitted_params_default()
-
-    # copied from sklearn
-    def _clone(self, estimator, *, safe=True):
-        """Construct a new unfitted estimator with the same parameters.
-
-        Clone does a deep copy of the model in an estimator
-        without actually copying attached data. It returns a new estimator
-        with the same parameters that has not been fitted on any data.
-
-        Parameters
-        ----------
-        estimator : {list, tuple, set} of estimator instance or a single \
-                estimator instance
-            The estimator or group of estimators to be cloned.
-        safe : bool, default=True
-            If safe is False, clone will fall back to a deep copy on objects
-            that are not estimators.
-
-        Returns
-        -------
-        estimator : object
-            The deep copy of the input, an estimator if input is an estimator.
-
-        Notes
-        -----
-        If the estimator's `random_state` parameter is an integer (or if the
-        estimator doesn't have a `random_state` parameter), an *exact clone* is
-        returned: the clone and the original estimator will give the exact same
-        results. Otherwise, *statistical clone* is returned: the clone might
-        return different results from the original estimator. More details can be
-        found in :ref:`randomness`.
-        """
-        estimator_type = type(estimator)
-        # XXX: not handling dictionaries
-        if estimator_type in (list, tuple, set, frozenset):
-            return estimator_type([self._clone(e, safe=safe) for e in estimator])
-        elif not hasattr(estimator, "get_params") or isinstance(estimator, type):
-            if not safe:
-                return deepcopy(estimator)
-            else:
-                if isinstance(estimator, type):
-                    raise TypeError(
-                        "Cannot clone object. "
-                        + "You should provide an instance of "
-                        + "scikit-learn estimator instead of a class."
-                    )
-                else:
-                    raise TypeError(
-                        "Cannot clone object '%s' (type %s): "
-                        "it does not seem to be a scikit-learn "
-                        "estimator as it does not implement a "
-                        "'get_params' method." % (repr(estimator), type(estimator))
-                    )
-
-        klass = estimator.__class__
-        new_object_params = estimator.get_params(deep=False)
-        for name, param in new_object_params.items():
-            new_object_params[name] = self._clone(param, safe=False)
-        new_object = klass(**new_object_params)
-        params_set = new_object.get_params(deep=False)
-
-        # quick sanity check of the parameters of the clone
-        for name in new_object_params:
-            param1 = new_object_params[name]
-            param2 = params_set[name]
-            if param1 is not param2:
-                raise RuntimeError(
-                    "Cannot clone object %s, as the constructor "
-                    "either does not set or modifies parameter %s" % (estimator, name)
-                )
-        return new_object

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -155,7 +155,7 @@ class BaseObject(_FlagManager):
         If successful, equal in value to ``type(self)(**self.get_params(deep=False))``.
         """
         self_params = self.get_params(deep=False)
-        self_clone = clone(self)
+        self_clone = self._clone(self)
 
         # if checking the clone is turned off, return now
         if not self.get_config()["check_clone"]:
@@ -1177,74 +1177,73 @@ class BaseEstimator(BaseObject):
         """
         return self._get_fitted_params_default()
 
+    # copied from sklearn
+    def _clone(self, estimator, *, safe=True):
+        """Construct a new unfitted estimator with the same parameters.
 
-# copied from sklearn
-def clone(estimator, *, safe=True):
-    """Construct a new unfitted estimator with the same parameters.
+        Clone does a deep copy of the model in an estimator
+        without actually copying attached data. It returns a new estimator
+        with the same parameters that has not been fitted on any data.
 
-    Clone does a deep copy of the model in an estimator
-    without actually copying attached data. It returns a new estimator
-    with the same parameters that has not been fitted on any data.
+        Parameters
+        ----------
+        estimator : {list, tuple, set} of estimator instance or a single \
+                estimator instance
+            The estimator or group of estimators to be cloned.
+        safe : bool, default=True
+            If safe is False, clone will fall back to a deep copy on objects
+            that are not estimators.
 
-    Parameters
-    ----------
-    estimator : {list, tuple, set} of estimator instance or a single \
-            estimator instance
-        The estimator or group of estimators to be cloned.
-    safe : bool, default=True
-        If safe is False, clone will fall back to a deep copy on objects
-        that are not estimators.
+        Returns
+        -------
+        estimator : object
+            The deep copy of the input, an estimator if input is an estimator.
 
-    Returns
-    -------
-    estimator : object
-        The deep copy of the input, an estimator if input is an estimator.
-
-    Notes
-    -----
-    If the estimator's `random_state` parameter is an integer (or if the
-    estimator doesn't have a `random_state` parameter), an *exact clone* is
-    returned: the clone and the original estimator will give the exact same
-    results. Otherwise, *statistical clone* is returned: the clone might
-    return different results from the original estimator. More details can be
-    found in :ref:`randomness`.
-    """
-    estimator_type = type(estimator)
-    # XXX: not handling dictionaries
-    if estimator_type in (list, tuple, set, frozenset):
-        return estimator_type([clone(e, safe=safe) for e in estimator])
-    elif not hasattr(estimator, "get_params") or isinstance(estimator, type):
-        if not safe:
-            return deepcopy(estimator)
-        else:
-            if isinstance(estimator, type):
-                raise TypeError(
-                    "Cannot clone object. "
-                    + "You should provide an instance of "
-                    + "scikit-learn estimator instead of a class."
-                )
+        Notes
+        -----
+        If the estimator's `random_state` parameter is an integer (or if the
+        estimator doesn't have a `random_state` parameter), an *exact clone* is
+        returned: the clone and the original estimator will give the exact same
+        results. Otherwise, *statistical clone* is returned: the clone might
+        return different results from the original estimator. More details can be
+        found in :ref:`randomness`.
+        """
+        estimator_type = type(estimator)
+        # XXX: not handling dictionaries
+        if estimator_type in (list, tuple, set, frozenset):
+            return estimator_type([clone(e, safe=safe) for e in estimator])
+        elif not hasattr(estimator, "get_params") or isinstance(estimator, type):
+            if not safe:
+                return deepcopy(estimator)
             else:
-                raise TypeError(
-                    "Cannot clone object '%s' (type %s): "
-                    "it does not seem to be a scikit-learn "
-                    "estimator as it does not implement a "
-                    "'get_params' method." % (repr(estimator), type(estimator))
+                if isinstance(estimator, type):
+                    raise TypeError(
+                        "Cannot clone object. "
+                        + "You should provide an instance of "
+                        + "scikit-learn estimator instead of a class."
+                    )
+                else:
+                    raise TypeError(
+                        "Cannot clone object '%s' (type %s): "
+                        "it does not seem to be a scikit-learn "
+                        "estimator as it does not implement a "
+                        "'get_params' method." % (repr(estimator), type(estimator))
+                    )
+
+        klass = estimator.__class__
+        new_object_params = estimator.get_params(deep=False)
+        for name, param in new_object_params.items():
+            new_object_params[name] = clone(param, safe=False)
+        new_object = klass(**new_object_params)
+        params_set = new_object.get_params(deep=False)
+
+        # quick sanity check of the parameters of the clone
+        for name in new_object_params:
+            param1 = new_object_params[name]
+            param2 = params_set[name]
+            if param1 is not param2:
+                raise RuntimeError(
+                    "Cannot clone object %s, as the constructor "
+                    "either does not set or modifies parameter %s" % (estimator, name)
                 )
-
-    klass = estimator.__class__
-    new_object_params = estimator.get_params(deep=False)
-    for name, param in new_object_params.items():
-        new_object_params[name] = clone(param, safe=False)
-    new_object = klass(**new_object_params)
-    params_set = new_object.get_params(deep=False)
-
-    # quick sanity check of the parameters of the clone
-    for name in new_object_params:
-        param1 = new_object_params[name]
-        param2 = params_set[name]
-        if param1 is not param2:
-            raise RuntimeError(
-                "Cannot clone object %s, as the constructor "
-                "either does not set or modifies parameter %s" % (estimator, name)
-            )
-    return new_object
+        return new_object

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -55,6 +55,7 @@ __all__ = [
     "test_clone_nan",
     "test_clone_estimator_types",
     "test_clone_class_rather_than_instance_raises_error",
+    "test_clone_sklearn_composite",
     "test_baseobject_repr",
     "test_baseobject_str",
     "test_baseobject_repr_mimebundle_",
@@ -929,6 +930,21 @@ def test_clone_class_rather_than_instance_raises_error(
     msg = "You should provide an instance of scikit-learn estimator"
     with pytest.raises(TypeError, match=msg):
         clone(fixture_class_parent)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("sklearn", severity="none"),
+    reason="skip test if sklearn is not available",
+)  # sklearn is part of the dev dependency set, test should be executed with that
+def test_clone_sklearn_composite(fixture_class_parent: Type[Parent]):
+    """Test clone with keyword parameter set to None."""
+    from sklearn.ensemble import GradientBoostingRegressor
+
+    sklearn_obj = GradientBoostingRegressor(random_state=5, learning_rate=0.02)
+    composite = ResetTester(a=sklearn_obj)
+    composite_set = composite.clone().set_params(a__random_state=42)
+    assert composite.get_params()["a__random_state"] == 5
+    assert composite_set.get_params()["a__random_state"] == 42
 
 
 # Tests of BaseObject pretty printing representation inspired by sklearn


### PR DESCRIPTION
The `clone` method of `BaseObject` would not properly clone `sklearn` estimator that are components (which do not have their own `clone`).

For now, this is fixed by replacing the faulty `skbase` `clone` with a copy of the `sklearn` `clone`.