### PR TITLE
Release 0.5.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest, windows-latest, macOS-latest]
-          python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+          python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macOS-11]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v3
@@ -65,11 +65,6 @@ jobs:
       matrix:
         include:
           # Window 64 bit
-          - os: windows-2019
-            python: 37
-            python-version: '3.7'
-            bitness: 64
-            platform_id: win_amd64
           - os: windows-2019
             python: 38
             python-version: '3.8'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 along with tools to make it easier to build your own packages that follow these
 design patterns.
 
-:rocket: Version 0.4.6 is now available. Checkout our
+:rocket: Version 0.5.0 is now available. Checkout our
 [release notes](https://skbase.readthedocs.io/en/latest/changelog.html).
 
 | Overview | |
@@ -30,7 +30,7 @@ For trouble shooting or more information, see our
 [detailed installation instructions](https://skbase.readthedocs.io/en/latest/user_documentation/installation.html).
 
 - **Operating system**: macOS X · Linux · Windows 8.1 or higher
-- **Python version**: Python 3.7, 3.8, 3.9, 3.10 and 3.11
+- **Python version**: Python 3.8, 3.9, 3.10 and 3.11
 - **Package managers**: [pip]
 
 [pip]: https://pip.pypa.io/en/stable/

--- a/docs/source/_static/switcher.json
+++ b/docs/source/_static/switcher.json
@@ -5,7 +5,12 @@
     "url": "https://skbase.readthedocs.io/en/latest/"
   },
   {
-    "name": "0.4.6 (stable)",
+    "name": "0.5.0 (stable)",
+    "version": "stable",
+    "url": "https://skbase.readthedocs.io/en/v0.5.0/"
+  },
+  {
+    "name": "0.4.6",
     "version": "stable",
     "url": "https://skbase.readthedocs.io/en/v0.4.6/"
   },

--- a/docs/source/get_started.rst
+++ b/docs/source/get_started.rst
@@ -13,7 +13,7 @@ Installation
 
 ``skbase`` currently supports:
 
-* environments with python version 3.7, 3.8, 3.9, 3.10 or 3.11
+* environments with python version 3.8, 3.9, 3.10 or 3.11
 * operating systems Mac OS X, Unix-like OS, Windows 8.1 and higher
 * installation via ``PyPi``
 

--- a/docs/source/user_documentation/changelog.rst
+++ b/docs/source/user_documentation/changelog.rst
@@ -18,6 +18,7 @@ For planned changes and upcoming releases, see our :ref:`roadmap`.
 ====================
 
 Maintenance release at python 3.7 end-of-life.
+
 Removes support for python 3.7.
 
 

--- a/docs/source/user_documentation/changelog.rst
+++ b/docs/source/user_documentation/changelog.rst
@@ -14,6 +14,13 @@ You can also subscribe to ``skbase``'s
 
 For planned changes and upcoming releases, see our :ref:`roadmap`.
 
+[0.5.0] - 2023-06-21
+====================
+
+Maintenance release at python 3.7 end-of-life.
+Removes support for python 3.7.
+
+
 [0.4.6] - 2023-06-16
 ====================
 

--- a/docs/source/user_documentation/installation.rst
+++ b/docs/source/user_documentation/installation.rst
@@ -6,7 +6,7 @@ Installation
 
 ``skbase`` currently supports:
 
-* environments with python version 3.7, 3.8, 3.9, 3.10 or 3.11
+* environments with python version 3.8, 3.9, 3.10 or 3.11
 * operating systems Mac OS X, Unix-like OS, Windows 8.1 and higher
 
 Checkout the full list of pre-compiled wheels on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "skbase"
-version = "0.4.6"
+name = "scikit-base"
+version = "0.5.0"
 description = "Base classes for sklearn-like parametric objects"
 authors = [
     {name = "sktime developers", email = "sktime.toolbox@gmail.com"},
@@ -26,13 +26,12 @@ classifiers = [
     "Operating System :: POSIX",
     "Operating System :: Unix",
     "Operating System :: MacOS",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
-requires-python = ">=3.7,<3.12"
+requires-python = ">=3.8,<3.12"
 dependencies = []
 
 [project.optional-dependencies]


### PR DESCRIPTION
Maintenance release 0.5.0 for python 3.7 end-of-life.

Python 3.7 is removed from:

* package metadata, support
* estimator metadata
* CI and tests
* documentation