### PR TITLE
[MNT] convert `black` `extend-exclude` parameter to single string

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ known_first_party = ["skbase"]
 
 [tool.black]
 line-length = 88
-extend-exclude = ["^/setup.py", "docs/conf.py"]
+extend-exclude = "^/setup.py docs/conf.py"
 
 [tool.pydocstyle]
 convention = "numpy"


### PR DESCRIPTION
In https://github.com/sktime/skbase/pull/205, `pre-commit` CI seems to complain that the `extend-exclude` parameter is not followed by a string (but a list of strings).

Attempting to fix this by changing the list of strings into a single string tha should hopefully comply with the expected syntax.