### PR TITLE
[MNT] separate windows CI element from unix based CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,6 @@ jobs:
       - name: Run tests
         run: |
           mkdir -p testdir/
-          cp .coveragerc testdir/
           cp setup.cfg testdir/
           python -m pytest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
 
 
   test-windows:
-    needs: test-nosoftdeps
+    needs: code-quality
     runs-on: windows-2019
     strategy:
       fail-fast: false  # to not fail all combinations if just one fail

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,17 +67,61 @@ jobs:
         run: |
           python skbase/_nopytest_tests.py
 
-  run-tests:
+
+  test-windows:
+    needs: test-nosoftdeps
+    runs-on: windows-2019
+    strategy:
+      fail-fast: false  # to not fail all combinations if just one fail
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          channels: anaconda, conda-forge,
+
+      - run: conda --version
+      - run: which python
+
+      - name: Fix windows paths
+        if: ${{ runner.os == 'Windows' }}
+        run: echo "C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Install conda libpython
+        run: conda install -c anaconda libpython
+
+      - name: Install sktime and dependencies
+        run: python -m pip install .[test]
+
+      - name: Show dependencies
+        run: python -m pip list
+
+      - name: Run tests
+        run: |
+          mkdir -p testdir/
+          cp .coveragerc testdir/
+          cp setup.cfg testdir/
+          python -m pytest
+
+      - name: Publish code coverage
+        uses: codecov/codecov-action@v3
+
+  test-unix:
     needs: code-quality
     name: Test ${{ matrix.os }}-${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
         fail-fast: false
         matrix:
-          os: [ubuntu-latest, windows-latest, macOS-latest]
+          os: [ubuntu-latest, macOS-latest]
           python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: conda-incubator/setup-miniconda@v2
         name: Set up conda
@@ -131,7 +175,7 @@ jobs:
         # non-zero exit code indicating a vulnerability has been found
       #   continue-on-error: false
 
-      - name: Generate Pytest coverage report
+      - name: Run tests
         shell: bash -l {0}
         run: |
           python -m pytest


### PR DESCRIPTION
Fixes https://github.com/sktime/skbase/issues/208, by replicating the `sktime` setup, which separates windows CI and unix based CI.