### PR TITLE
[MNT] update `__init__` version

### DIFF
--- a/skbase/__init__.py
+++ b/skbase/__init__.py
@@ -8,7 +8,7 @@ sktime design principles in your project.
 """
 from typing import List
 
-__version__: str = "0.4.6"
+__version__: str = "0.5.0"
 
 __author__: List[str] = ["fkiraly", "RNKuhns", "mloning"]
 __all__: List[str] = []


### PR DESCRIPTION
The version in `__init__` has not been properly updated - this PR fixes that.

Upon 0.5.1 or 0.6.0, a replacefrom 0.5.0 should ensure consistencyl