### PR TITLE
[ENH] remove `sklearn` dependency in `test_get_params`

### DIFF
--- a/skbase/testing/test_all_objects.py
+++ b/skbase/testing/test_all_objects.py
@@ -659,21 +659,17 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         assert not hasattr(object_instance, "test__attr")
         object_instance.test__attr = 42
 
-    @pytest.mark.skipif(
-        not _check_soft_dependencies("sklearn", severity="none"),
-        reason="skip test if sklearn is not available",
-    )  # sklearn is part of the dev dependency set, test should be executed with that
     def test_get_params(self, object_instance):
         """Check that get_params works correctly, against sklearn interface."""
-        from sklearn.utils.estimator_checks import (
-            check_get_params_invariance as _check_get_params_invariance,
-        )
-
         params = object_instance.get_params()
         assert isinstance(params, dict)
-        _check_get_params_invariance(
-            object_instance.__class__.__name__, object_instance
-        )
+
+        e = object_instance.clone()
+
+        shallow_params = e.get_params(deep=False)
+        deep_params = e.get_params(deep=True)
+
+        assert all(item in deep_params.items() for item in shallow_params.items())
 
     def test_set_params(self, object_instance):
         """Check that set_params works correctly."""


### PR DESCRIPTION
This PR removes the `sklearn` dependency in `get_test_params`, by replacing `_check_get_params_invariance` with an `skbase`-native implementation.

The call to `clone` is replaced with the object's own `clone`method.