### PR TITLE
[ENH] meta-object mixins

### DIFF
--- a/skbase/base/__init__.py
+++ b/skbase/base/__init__.py
@@ -9,7 +9,12 @@ sktime design principles in your project.
 from typing import List
 
 from skbase.base._base import BaseEstimator, BaseObject
-from skbase.base._meta import BaseMetaEstimator, BaseMetaObject
+from skbase.base._meta import (
+    BaseMetaEstimator,
+    BaseMetaEstimatorMixin,
+    BaseMetaObject,
+    BaseMetaObjectMixin,
+)
 
 __author__: List[str] = ["mloning", "RNKuhns", "fkiraly"]
 __all__: List[str] = [
@@ -17,4 +22,6 @@ __all__: List[str] = [
     "BaseEstimator",
     "BaseMetaEstimator",
     "BaseMetaObject",
+    "BaseMetaEstimatorMixin",
+    "BaseMetaObjectMixin",
 ]

--- a/skbase/base/_meta.py
+++ b/skbase/base/_meta.py
@@ -856,12 +856,48 @@ class BaseMetaObject(_MetaObjectMixin, _MetaTagLogicMixin, BaseObject):
     this would allow `get_params` and `set_params` to retrieve and update the
     parameters of the objects in each step.
 
+    Note: if inheriting from an abstract descendant of `BaseObject`, use
+    ``BaseMetaObjectMixin`` and not ``BaseMetaObject``.
+
     See Also
     --------
+    BaseMetaObjectMixin :
+        Mixin for inheriting from abstract descendants of ``BaseObject``.
+        Same as ``BaseMetaObject``, but does not inherit from ``BaseObject``.
     BaseMetaEstimator :
-        Expands on `BaseMetaObject` by adding functionality for getting fitted
-        parameters from a class's component estimators. `BaseEstimator` should
-        be used when you want to create a meta estimator.
+        Expands on ``BaseMetaObject`` by adding functionality for getting fitted
+        parameters from a class's component estimators.
+    """
+
+
+class BaseMetaObjectMixin(_MetaObjectMixin, _MetaTagLogicMixin):
+    """Parameter and tag management for objects composed of named objects.
+
+    Allows objects to get and set nested parameters when a parameter of the the
+    class has values that follow the named object specification. For example,
+    in a pipeline class with the the "step" parameter accepting named objects,
+    this would allow `get_params` and `set_params` to retrieve and update the
+    parameters of the objects in each step.
+
+    Mixin for inheriting from abstract descendants of ``BaseObject``.
+    Intended use is inheriting as follows:
+
+    ``class MyAbstractBaseClass(BaseObject)``, and then
+    ``class MyConcreteClass(BaseMetaObjectMixin, MyAbstractBaseClass)``
+
+    The mixin will override:
+    ``get_params``, ``set_params``, ``_get_params``, ``_set_params``,
+    ``_get_fitted_params``, ``_sk_visual_block_``
+
+    See Also
+    --------
+    BaseMetaEstimatorMixin :
+        Expands on ``BaseMetaObjectMixin`` by adding functionality for getting fitted
+        parameters from a class's component estimators.
+    BaseMetaObject :
+        same as ``BaseMetaObjectMixin``, but also inherits from ``BaseObject``.
+        Use for a standalone meta-object class.
+        Do not use if inheriting from an abstract descendant of ``BaseObject``.
     """
 
 
@@ -874,10 +910,48 @@ class BaseMetaEstimator(_MetaObjectMixin, _MetaTagLogicMixin, BaseEstimator):
     this would allow `get_params` and `set_params` to retrieve and update the
     parameters of the objects in each step.
 
+    Note: if inheriting from an abstract descendant of `BaseEstimator`, use
+    ``BaseMetaEstimatorMixin`` and not ``BaseMetaEstimator``.
+
     See Also
     --------
+    BaseMetaEstimatorMixin :
+        Mixin for inheriting from abstract descendants of ``BaseObject``.
+        Same as ``BaseMetaObject``, but does not inherit from ``BaseObject``.
     BaseMetaObject :
-        Provides similar functionality to  `BaseMetaEstimator` for getting
-        parameters from a class's component objects, but does not have the
-        estimator interface.
+        Provides similar functionality to  `BaseMetaEstimator`,
+        but does not have the estimator interface for fitting and fitted parameters.
+    """
+
+
+class BaseMetaEstimatorMixin(_MetaObjectMixin, _MetaTagLogicMixin):
+    """Parameter and tag management for estimators composed of named objects.
+
+    Allows estimators to get and set nested parameters when a parameter of the the
+    class has values that follow the named object specification. For example,
+    in a pipeline class with the the "step" parameter accepting named objects,
+    this would allow `get_params` and `set_params` to retrieve and update the
+    parameters of the objects in each step.
+
+    Mixin for inheriting from abstract descendants of ``BaseEstimator``.
+    Intended use is inheriting as follows:
+
+    ``class MyAbstractBaseClass(BaseEstimator)``, and then
+    ``class MyConcreteClass(BaseMetaEstimatorMixin, MyAbstractBaseClass)``
+
+    Note: the order of inheritance is important.
+
+    The mixin will override:
+    ``get_params``, ``set_params``, ``_get_params``, ``_set_params``,
+    ``_get_fitted_params``, ``_sk_visual_block_``
+
+    See Also
+    --------
+    BaseMetaObjectMixin :
+        Provides similar functionality to  `BaseMetaEstimatorMixin`,
+        but does not have the estimator interface for fitting and fitted parameters.
+    BaseMetaEstimator :
+        same as ``BaseMetaEstimatorMixin``, but also inherits from ``BaseEstimator``.
+        Use for a standalone meta-estimator class.
+        Do not use if inheriting from an abstract descendant of ``BaseEstimator``.
     """

--- a/skbase/tests/conftest.py
+++ b/skbase/tests/conftest.py
@@ -85,11 +85,18 @@ SKBASE_PUBLIC_CLASSES_BY_MODULE = {
     "skbase.base": (
         "BaseEstimator",
         "BaseMetaEstimator",
+        "BaseMetaEstimatorMixin",
         "BaseMetaObject",
+        "BaseMetaObjectMixin",
         "BaseObject",
     ),
     "skbase.base._base": ("BaseEstimator", "BaseObject"),
-    "skbase.base._meta": ("BaseMetaObject", "BaseMetaEstimator"),
+    "skbase.base._meta": (
+        "BaseMetaObject",
+        "BaseMetaObjectMixin",
+        "BaseMetaEstimator",
+        "BaseMetaEstimatorMixin",
+    ),
     "skbase.base._pretty_printing._pprint": ("KeyValTuple", "KeyValTupleParam"),
     "skbase.lookup._lookup": (),
     "skbase.testing": ("BaseFixtureGenerator", "QuickTester", "TestAllObjects"),
@@ -104,7 +111,9 @@ SKBASE_CLASSES_BY_MODULE.update(
     {
         "skbase.base._meta": (
             "BaseMetaObject",
+            "BaseMetaObjectMixin",
             "BaseMetaEstimator",
+            "BaseMetaEstimatorMixin",
             "_MetaObjectMixin",
             "_MetaTagLogicMixin",
         ),


### PR DESCRIPTION
This PR adds meta-object mixins - previously, the package provided only classes inheriting from `BaseObject` or `BaseEstimator`, which can create multiple inheritance conflicts if downstream needs to inherit from an abstract desceendant of `BaseObject` or `BaseEstimator`.

This is also more in line with the actual use cases in `sktime` and `skpro`.