### PR TITLE
[ENH] move tests for dependency checks and `deep_equals` to `utils` module

### DIFF
--- a/skbase/testing/test_all_objects.py
+++ b/skbase/testing/test_all_objects.py
@@ -18,8 +18,8 @@ from skbase.lookup import all_objects
 from skbase.testing.utils._conditional_fixtures import (
     create_conditional_fixtures_and_names,
 )
-from skbase.testing.utils._dependencies import _check_soft_dependencies
 from skbase.testing.utils.inspect import _get_args
+from skbase.utils.dependencies import _check_soft_dependencies
 from skbase.utils.deep_equals import deep_equals
 
 __author__: List[str] = ["fkiraly"]

--- a/skbase/testing/utils/tests/__init__.py
+++ b/skbase/testing/utils/tests/__init__.py
@@ -1,2 +1,0 @@
-# -*- coding: utf-8 -*-
-"""Testing utilities of the test framework."""

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -77,9 +77,9 @@ import pytest
 import scipy.sparse as sp
 
 from skbase.base import BaseEstimator, BaseObject
-from skbase.utils.dependencies import _check_soft_dependencies
 from skbase.tests.conftest import Child, Parent
 from skbase.tests.mock_package.test_mock_package import CompositionDummy
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 # TODO: Determine if we need to add sklearn style test of

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -77,7 +77,7 @@ import pytest
 import scipy.sparse as sp
 
 from skbase.base import BaseEstimator, BaseObject
-from skbase.testing.utils._dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from skbase.tests.conftest import Child, Parent
 from skbase.tests.mock_package.test_mock_package import CompositionDummy
 

--- a/skbase/utils/dependencies/tests/__init__.py
+++ b/skbase/utils/dependencies/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Testing utilities for depeendency checkers."""

--- a/skbase/utils/dependencies/tests/test_check_dependencies.py
+++ b/skbase/utils/dependencies/tests/test_check_dependencies.py
@@ -3,7 +3,7 @@
 import pytest
 from packaging.requirements import InvalidRequirement
 
-from skbase.testing.utils._dependencies import _check_soft_dependencies
+from skbase.utils.dependencies._dependencies import _check_soft_dependencies
 
 
 def test_check_soft_deps():

--- a/skbase/utils/tests/test_deep_equals.py
+++ b/skbase/utils/tests/test_deep_equals.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 import numpy as np
 import pytest
 
-from skbase.testing.utils._dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from skbase.utils.deep_equals import deep_equals
 
 # examples used for comparison below

--- a/skbase/utils/tests/test_deep_equals.py
+++ b/skbase/utils/tests/test_deep_equals.py
@@ -5,8 +5,8 @@ from copy import deepcopy
 import numpy as np
 import pytest
 
-from skbase.utils.dependencies import _check_soft_dependencies
 from skbase.utils.deep_equals import deep_equals
+from skbase.utils.dependencies import _check_soft_dependencies
 
 # examples used for comparison below
 EXAMPLES = [


### PR DESCRIPTION
This PR moves the tests for dependency checks and `deep_equals` to the `utils` module where those utilities reside.