### PR TITLE
[MNT] python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false  # to not fail all combinations if just one fail
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v3
@@ -118,7 +118,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest, macOS-latest]
-          python-version: ['3.8', '3.9', '3.10', '3.11']
+          python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macOS-11]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v3
@@ -83,6 +83,11 @@ jobs:
           - os: windows-2019
             python: 311
             python-version: 3.11
+            bitness: 64
+            platform_id: win_amd64
+          - os: windows-2019
+            python: 312
+            python-version: 3.12
             bitness: 64
             platform_id: win_amd64
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For trouble shooting or more information, see our
 [detailed installation instructions](https://skbase.readthedocs.io/en/latest/user_documentation/installation.html).
 
 - **Operating system**: macOS X · Linux · Windows 8.1 or higher
-- **Python version**: Python 3.8, 3.9, 3.10 and 3.11
+- **Python version**: Python 3.8, 3.9, 3.10, 3.11 and 3.12
 - **Package managers**: [pip]
 
 [pip]: https://pip.pypa.io/en/stable/

--- a/docs/source/get_started.rst
+++ b/docs/source/get_started.rst
@@ -13,7 +13,7 @@ Installation
 
 ``skbase`` currently supports:
 
-* environments with python version 3.8, 3.9, 3.10 or 3.11
+* environments with python version 3.8, 3.9, 3.10, 3.11 or 3.12
 * operating systems Mac OS X, Unix-like OS, Windows 8.1 and higher
 * installation via ``PyPi``
 

--- a/docs/source/user_documentation/installation.rst
+++ b/docs/source/user_documentation/installation.rst
@@ -6,7 +6,7 @@ Installation
 
 ``skbase`` currently supports:
 
-* environments with python version 3.8, 3.9, 3.10 or 3.11
+* environments with python version 3.8, 3.9, 3.10, 3.11 or 3.12
 * operating systems Mac OS X, Unix-like OS, Windows 8.1 and higher
 
 Checkout the full list of pre-compiled wheels on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.8,<3.13"
 dependencies = []
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 requires-python = ">=3.8,<3.12"
 dependencies = []


### PR DESCRIPTION
This PR adds python 3.12 in the `pyproject.toml`, project documentation, and CI.

For release with 0.6.0