### PR TITLE
[BUG] correct parameter name in `TestAllObjects` `all_objects` call

### DIFF
--- a/skbase/testing/test_all_objects.py
+++ b/skbase/testing/test_all_objects.py
@@ -143,7 +143,7 @@ class BaseFixtureGenerator:
         return all_objects(
             object_types=getattr(self, "object_type_filter", None),
             return_names=False,
-            exclude_estimators=self.exclude_objects,
+            exclude_objects=self.exclude_objects,
             package_name=self.package_name,
         )
 


### PR DESCRIPTION
This corrects the parameter name in `TestAllObjects` `all_objects` call, from `exclude_estimators` to `exclude_objects`.