### PR TITLE
[ENH] address readthedocs build failures

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,7 @@ python:
       path: .
       extra_requirements:
         - docs
+        - test
 build:
   os: ubuntu-20.04
   tools:

--- a/skbase/utils/tests/test_check.py
+++ b/skbase/utils/tests/test_check.py
@@ -8,8 +8,6 @@ tests in this module include:
 - test_is_scalar_nan_output to verify _is_scalar_nan outputs expected value for
   different inputs.
 """
-import numpy as np
-
 from skbase.utils._check import _is_scalar_nan
 
 __author__ = ["RNKuhns"]
@@ -17,6 +15,8 @@ __author__ = ["RNKuhns"]
 
 def test_is_scalar_nan_output():
     """Test that _is_scalar_nan outputs expected value for different inputs."""
+    import numpy as np
+
     assert _is_scalar_nan(np.nan) is True
     assert _is_scalar_nan(float("nan")) is True
     assert _is_scalar_nan(None) is False

--- a/skbase/utils/tests/test_deep_equals.py
+++ b/skbase/utils/tests/test_deep_equals.py
@@ -2,7 +2,6 @@
 """Tests for deep_equals utility."""
 from copy import deepcopy
 
-import numpy as np
 import pytest
 
 from skbase.utils.deep_equals import deep_equals
@@ -14,13 +13,18 @@ EXAMPLES = [
     [],
     ((((())))),
     [([([([()])])])],
-    np.array([2, 3, 4]),
-    np.array([2, 4, 5]),
     3.5,
     4.2,
-    np.nan,
 ]
 
+if _check_soft_dependencies("numpy", severity="none"):
+    import numpy as np
+
+    EXAMPLES += [
+        np.array([2, 3, 4]),
+        np.array([2, 4, 5]),
+        np.nan,
+    ]
 
 if _check_soft_dependencies("pandas", severity="none"):
     import pandas as pd


### PR DESCRIPTION
This PR solves the readthedocs build issue by:

* isolating some `numpy` imports
* adding the test dep set as required for readthedocs builds to avoid import failures (pytest)