### PR TITLE
[BUG] ensure `deep_equals` plugins are passed on to all recursions

### DIFF
--- a/skbase/utils/deep_equals/_deep_equals.py
+++ b/skbase/utils/deep_equals/_deep_equals.py
@@ -161,10 +161,7 @@ def _pandas_equals(x, y, return_msg=False, deep_equals=None):
         if x.dtype == "object":
             index_equal = x.index.equals(y.index)
             values_equal, values_msg = deep_equals(
-                list(x.to_numpy()),
-                list(y.to_numpy()),
-                return_msg=True,
-                deep_equals=deep_equals,
+                list(x.to_numpy()), list(y.to_numpy()), return_msg=True
             )
             if not values_equal:
                 msg = ".values" + values_msg
@@ -185,9 +182,7 @@ def _pandas_equals(x, y, return_msg=False, deep_equals=None):
         # if columns are equal and at least one is object, recurse over Series
         if sum(x.dtypes == "object") > 0:
             for c in x.columns:
-                is_equal, msg = deep_equals(
-                    x[c], y[c], return_msg=True, deep_equals=deep_equals
-                )
+                is_equal, msg = deep_equals(x[c], y[c], return_msg=True)
                 if not is_equal:
                     return ret(False, f"[{c!r}]" + msg)
             return ret(True, "")
@@ -241,7 +236,7 @@ def _tuple_equals(x, y, return_msg=False, deep_equals=None):
         yi = y[i]
 
         # recurse through xi/yi
-        is_equal, msg = deep_equals(xi, yi, return_msg=True, deep_equals=deep_equals)
+        is_equal, msg = deep_equals(xi, yi, return_msg=True)
         if not is_equal:
             return ret(False, f"[{i}]" + msg)
 
@@ -294,7 +289,7 @@ def _dict_equals(x, y, return_msg=False, deep_equals=None):
         yi = y[key]
 
         # recurse through xi/yi
-        is_equal, msg = deep_equals(xi, yi, return_msg=True, deep_equals=deep_equals)
+        is_equal, msg = deep_equals(xi, yi, return_msg=True)
         if not is_equal:
             return ret(False, f"[{key}]" + msg)
 
@@ -332,9 +327,7 @@ def _fh_equals_plugin(x, y, return_msg=False, deep_equals=None):
         return ret(False, ".is_relative")
 
     # recurse through values of x, y
-    is_equal, msg = deep_equals(
-        x._values, y._values, return_msg=True, deep_equals=deep_equals
-    )
+    is_equal, msg = deep_equals(x._values, y._values, return_msg=True)
     if not is_equal:
         return ret(False, ".values" + msg)
 
@@ -387,9 +380,9 @@ def deep_equals_custom(x, y, return_msg=False, plugins=None):
 
     # recursion through lists, tuples and dicts
     if isinstance(x, (list, tuple)):
-        return ret(*_tuple_equals(x, y, return_msg=True))
+        return ret(*_tuple_equals(x, y, return_msg=True, deep_equals=deep_equals))
     elif isinstance(x, dict):
-        return ret(*_dict_equals(x, y, return_msg=True))
+        return ret(*_dict_equals(x, y, return_msg=True, deep_equals=deep_equals))
     elif _is_npnan(x):
         return ret(_is_npnan(y), f"type(x)={type(x)} != type(y)={type(y)}")
     elif isclass(x):

--- a/skbase/utils/deep_equals/_deep_equals.py
+++ b/skbase/utils/deep_equals/_deep_equals.py
@@ -378,11 +378,17 @@ def deep_equals_custom(x, y, return_msg=False, plugins=None):
     # we now know all types are the same
     # so now we compare values
 
+    # we need to pass in the same plugins, so we curry
+    def deep_equals_curried(x, y, return_msg=False):
+        return deep_equals_custom(x, y, return_msg=return_msg, plugins=plugins)
+
     # recursion through lists, tuples and dicts
     if isinstance(x, (list, tuple)):
-        return ret(*_tuple_equals(x, y, return_msg=True, deep_equals=deep_equals))
+        dec = deep_equals_curried
+        return ret(*_tuple_equals(x, y, return_msg=True, deep_equals=dec))
     elif isinstance(x, dict):
-        return ret(*_dict_equals(x, y, return_msg=True, deep_equals=deep_equals))
+        dec = deep_equals_curried
+        return ret(*_dict_equals(x, y, return_msg=True, deep_equals=dec))
     elif _is_npnan(x):
         return ret(_is_npnan(y), f"type(x)={type(x)} != type(y)={type(y)}")
     elif isclass(x):
@@ -398,12 +404,6 @@ def deep_equals_custom(x, y, return_msg=False, plugins=None):
             sig = signature(plugin)
             # check if deep_equals is an argument of the plugin
             if "deep_equals" in sig.parameters:
-                # we need to pass in the same plugins, so we curry
-                def deep_equals_curried(x, y, return_msg=False):
-                    return deep_equals_custom(
-                        x, y, return_msg=return_msg, plugins=plugins
-                    )
-
                 kwargs = {"deep_equals": deep_equals_curried}
             else:
                 kwargs = {}

--- a/skbase/utils/deep_equals/_deep_equals.py
+++ b/skbase/utils/deep_equals/_deep_equals.py
@@ -161,7 +161,10 @@ def _pandas_equals(x, y, return_msg=False, deep_equals=None):
         if x.dtype == "object":
             index_equal = x.index.equals(y.index)
             values_equal, values_msg = deep_equals(
-                list(x.to_numpy()), list(y.to_numpy()), return_msg=True
+                list(x.to_numpy()),
+                list(y.to_numpy()),
+                return_msg=True,
+                deep_equals=deep_equals,
             )
             if not values_equal:
                 msg = ".values" + values_msg
@@ -182,7 +185,9 @@ def _pandas_equals(x, y, return_msg=False, deep_equals=None):
         # if columns are equal and at least one is object, recurse over Series
         if sum(x.dtypes == "object") > 0:
             for c in x.columns:
-                is_equal, msg = deep_equals(x[c], y[c], return_msg=True)
+                is_equal, msg = deep_equals(
+                    x[c], y[c], return_msg=True, deep_equals=deep_equals
+                )
                 if not is_equal:
                     return ret(False, f"[{c!r}]" + msg)
             return ret(True, "")
@@ -198,7 +203,7 @@ def _pandas_equals(x, y, return_msg=False, deep_equals=None):
         )
 
 
-def _tuple_equals(x, y, return_msg=False):
+def _tuple_equals(x, y, return_msg=False, deep_equals=None):
     """Test two tuples or lists for equality.
 
     Correct if tuples/lists contain the following valid types:
@@ -236,14 +241,14 @@ def _tuple_equals(x, y, return_msg=False):
         yi = y[i]
 
         # recurse through xi/yi
-        is_equal, msg = deep_equals(xi, yi, return_msg=True)
+        is_equal, msg = deep_equals(xi, yi, return_msg=True, deep_equals=deep_equals)
         if not is_equal:
             return ret(False, f"[{i}]" + msg)
 
     return ret(True, "")
 
 
-def _dict_equals(x, y, return_msg=False):
+def _dict_equals(x, y, return_msg=False, deep_equals=None):
     """Test two dicts for equality.
 
     Correct if dicts contain the following valid types:
@@ -289,7 +294,7 @@ def _dict_equals(x, y, return_msg=False):
         yi = y[key]
 
         # recurse through xi/yi
-        is_equal, msg = deep_equals(xi, yi, return_msg=True)
+        is_equal, msg = deep_equals(xi, yi, return_msg=True, deep_equals=deep_equals)
         if not is_equal:
             return ret(False, f"[{key}]" + msg)
 
@@ -327,7 +332,9 @@ def _fh_equals_plugin(x, y, return_msg=False, deep_equals=None):
         return ret(False, ".is_relative")
 
     # recurse through values of x, y
-    is_equal, msg = deep_equals(x._values, y._values, return_msg=True)
+    is_equal, msg = deep_equals(
+        x._values, y._values, return_msg=True, deep_equals=deep_equals
+    )
     if not is_equal:
         return ret(False, ".values" + msg)
 

--- a/skbase/utils/deep_equals/_deep_equals.py
+++ b/skbase/utils/deep_equals/_deep_equals.py
@@ -97,7 +97,7 @@ def _is_pandas(x):
 def _is_npndarray(x):
     import numpy as np
 
-    return isinstance(x, np.array)
+    return isinstance(x, np.ndarray)
 
 
 def _is_npnan(x):

--- a/skbase/utils/deep_equals/_deep_equals.py
+++ b/skbase/utils/deep_equals/_deep_equals.py
@@ -7,12 +7,11 @@ Objects compared can have one of the following valid types:
     lists, tuples, or dicts of a valid type (recursive)
 """
 from inspect import isclass, signature
-from typing import List
 
 from skbase.utils.deep_equals._common import _make_ret
 
-__author__: List[str] = ["fkiraly"]
-__all__: List[str] = ["deep_equals"]
+__author__ = ["fkiraly"]
+__all__ = ["deep_equals"]
 
 
 # flag variables for available soft dependencies
@@ -96,8 +95,9 @@ def _is_pandas(x):
 
 
 def _is_npndarray(x):
-    clstr = type(x).__name__
-    return clstr == "ndarray"
+    import numpy as np
+
+    return isinstance(x, np.array)
 
 
 def _is_npnan(x):

--- a/skbase/utils/tests/test_deep_equals.py
+++ b/skbase/utils/tests/test_deep_equals.py
@@ -24,6 +24,7 @@ if _check_soft_dependencies("numpy", severity="none"):
         np.array([2, 3, 4]),
         np.array([2, 4, 5]),
         np.nan,
+        {"a": np.array([2, 3, 4]), "b": np.array([4, 3, 2])},
     ]
 
 if _check_soft_dependencies("pandas", severity="none"):

--- a/skbase/utils/tests/test_deep_equals.py
+++ b/skbase/utils/tests/test_deep_equals.py
@@ -24,7 +24,10 @@ if _check_soft_dependencies("numpy", severity="none"):
         np.array([2, 3, 4]),
         np.array([2, 4, 5]),
         np.nan,
+        # these cases test that plugins are passed to recursions
+        # in this case, the numpy equality plugin
         {"a": np.array([2, 3, 4]), "b": np.array([4, 3, 2])},
+        [np.array([2, 3, 4]), np.array([4, 3, 2])],
     ]
 
 if _check_soft_dependencies("pandas", severity="none"):


### PR DESCRIPTION
This PR fixes an unreported bug that prevented `deep_equals` plugins to be passed in some recursions.

The recursions have been fixed, and test cases have been added.