### PR TITLE
[MNT] Fixed spelling mistakes as identified by `codespell` and `typos`

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,6 +9,6 @@
 ## Reporting a Vulnerability
 
 Please report security vulnerabilities by email to `rk.skbase@gmail.com`.
-This email will be forward to the relevent members of the `skbase` development team.
+This email will be forward to the relevant members of the `skbase` development team.
 
 If the security vulnerability is accepted, a patch will be developed privately to provide a bugfix release as soon as possible.

--- a/docs/source/about/governance.rst
+++ b/docs/source/about/governance.rst
@@ -35,7 +35,7 @@ Code of Conduct
 ===============
 
 The ``skbase`` project believes that everyone should be able to participate
-in our community without fear of harrassment or discrimination (see our
+in our community without fear of harassment or discrimination (see our
 :ref:`Code of Conduct guide <coc>`).
 
 Roles
@@ -172,7 +172,7 @@ Lazy consensus
 
 Changes are approved "lazily" when after *reasonable* amount of time
 the change receives approval from at least one core developer
-and no rejections (excercise of core developer veto right).
+and no rejections (exercise of core developer veto right).
 
 .. _gov_bep:
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -270,7 +270,7 @@ nbsphinx_execute = "never"  # always  # whether to run notebooks
 nbsphinx_allow_errors = False  # False
 nbsphinx_timeout = 600  # seconds, set to -1 to disable timeout
 
-# add Binder launch buttom at the top
+# add Binder launch button at the top
 current_file = "{{ env.doc2path( env.docname, base=None) }}"
 
 # make sure Binder points to latest stable release, not main

--- a/docs/source/contribute/code_of_conduct.rst
+++ b/docs/source/contribute/code_of_conduct.rst
@@ -5,7 +5,7 @@ Code of conduct
 ===============
 
 The ``skbase`` project believes that everyone should be able to participate
-in our community without fear of harrassment or discrimination. All contributors
+in our community without fear of harassment or discrimination. All contributors
 are expected to show respect and courtesy to other members of the community
 at all times.
 
@@ -21,4 +21,4 @@ to Dr. Franz Király by email at franz.kiraly@sktime.net.
     ``skbase`` is a new project, and processes associated with the project's
     Code of Conduct (including how to report incidents) and may change as the
     project matures. However, ``skbase``'s Code of Conduct will remain
-    dedicated to promoting a community without harrassment and discrimination.
+    dedicated to promoting a community without harassment and discrimination.

--- a/docs/source/contribute/development/developer_guide/creating_docs.rst
+++ b/docs/source/contribute/development/developer_guide/creating_docs.rst
@@ -112,9 +112,9 @@ to the user guide and link to it if it does not already exist.
 See Also
 ~~~~~~~~
 
-This section should reference other ``skbase`` code artifcats related to the code
+This section should reference other ``skbase`` code artifacts related to the code
 artifact being documented by the docstring. Developers should use judgement in
-determining related code artifcats.
+determining related code artifacts.
 
 Notes
 ~~~~~
@@ -172,7 +172,7 @@ a minimum this should include a single example that illustrates basic functional
 
 
 The examples should use simple data (e.g. randomly generated data, etc)
-generated using a ``skbase`` dependency and whereever possible only depend
+generated using a ``skbase`` dependency and wherever possible only depend
 on ``skbase`` or its core dependencies. Examples should also be designed to
 run quickly where possible. For quick running code artifacts, additional examples
 can be included to illustrate the affect of different parameter settings.

--- a/docs/source/contribute/development/developer_guide/dependencies.rst
+++ b/docs/source/contribute/development/developer_guide/dependencies.rst
@@ -18,7 +18,7 @@ Types of dependencies
 
 Making it easy to install and use ``skbase`` in a variety of projects is
 on of ``skbase``'s goals. Therefore, we seeks to minimizing the number of
-dependencies needed to provide the proejct's functionality.
+dependencies needed to provide the project's functionality.
 
 Soft Dependencies
 =================

--- a/docs/source/contribute/development/reviewer_guide.rst
+++ b/docs/source/contribute/development/reviewer_guide.rst
@@ -45,7 +45,7 @@ Code Review
 
 .. _reviewer_guide_doc:
 
-Documenation Review
+Documentation Review
 ====================
 
 * Are the docstrings complete and understandable to users?

--- a/docs/source/user_documentation/changelog.rst
+++ b/docs/source/user_documentation/changelog.rst
@@ -341,7 +341,7 @@ Highlights
 
 - Expanded test coverage of ``skbase.base`` and ``skbase.lookup`` modules and
   ``skbase`` exceptions (:pr:`62`, :pr:`80`, :pr:`91`) :user:`rnkuhns`
-- Add equality dunder to ``BaseObject`` to allow ``BaseObejct``-s to be compared based
+- Add equality dunder to ``BaseObject`` to allow ``BaseObject``-s to be compared based
   on parameter equality (:pr:`86`) :user:`fkiraly`
 - Add ``sktime``-like interface for retrieving fitted parameters to ``BaseEstimator``
   (:pr:`87`) :user:`fkiraly`

--- a/docs/source/user_documentation/changelog.rst
+++ b/docs/source/user_documentation/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-All notable changes to this project beggining with version 0.1.0 will be
+All notable changes to this project beginning with version 0.1.0 will be
 documented in this file. The format is based on
 `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_ and we adhere
 to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_. The source
@@ -228,7 +228,7 @@ Dependency changes
 * ``scikit-learn``, ``typing-extensions``, and ``pytest`` are no longer
   core dependencies.
   ``pytest`` remains a dependency in ``dev`` and ``test`` dependency sets.
-* ``scikit-learn`` is now part of the ``dev`` and ``test`` depency sets,
+* ``scikit-learn`` is now part of the ``dev`` and ``test`` dependency sets,
   as it is required to test compatibility with ``scikit-learn``
 * a dependency conflict has been resolved in the ``docs`` dependency set for
   the docs build,

--- a/enhancement_proposals/sbep_1.md
+++ b/enhancement_proposals/sbep_1.md
@@ -21,9 +21,9 @@ Specifically,`skbase` will provide:
   illustrating how developers can use `skbase` in their own projects and
   providing test cases
 - A [template repository](#Template-Repository) that developers can clone to
-  easiliy set up a a new project using `skbase`'s principles
+  easily set up a a new project using `skbase`'s principles
 
-Although the package will initially inherit some of this functinality from
+Although the package will initially inherit some of this functionality from
 `scikit-learn` the goal is to make it easy to use the design patterns in a
 variety of contexts, not just those that depend on `scikit-learn`. Accordingly,
 `skbase` has a goal of providing the proposed functionality with minimal
@@ -61,7 +61,7 @@ contexts. This includes:
 - [BaseMetaObject](#BaseMetaObjectMixin): A mixin that provides a high-level interface
   for working with classes composed of collections of `BaseObject`s.
 - [Base pipeline classes](#Base-Pipeline-Classes): `BaseObject`s that also
-  inherit from `BaseMetaObject` mixin and provide additional generic functionalty
+  inherit from `BaseMetaObject` mixin and provide additional generic functionality
   for common pipeline use cases.
 
 #### BaseObject
@@ -195,7 +195,7 @@ collecting and testing classes that descend from BaseObject.
 This benefits users by:
 
 - Making it easy to incorporate these tests in their own projects, reducing the need
-  to spend time testing that their classes comply with the interface inheritted
+  to spend time testing that their classes comply with the interface inherited
   from `BaseObject`.
 - Providing an extensible framework they can use to collect and test their own
   object interfaces and functionality.
@@ -203,7 +203,7 @@ This benefits users by:
 #### `skbase.validate`: Validating and Comparing BaseObjects
 
 When developing packages that include parametric objects, verifying and comparing
-objects is a common worfklow.
+objects is a common workflow.
 
 To aid this `skbase` will provide functions to:
 - Check if a `BaseObject` complies with the expected interface

--- a/skbase/__init__.py
+++ b/skbase/__init__.py
@@ -3,7 +3,7 @@
 # copyright: skbase developers, BSD-3-Clause License (see LICENSE file)
 """:mod:`skbase` contains tools for creating and working with parametric objects.
 
-The included functionality makes it easy to re-use scikit-learn and
+The included functionality makes it easy to reuse scikit-learn and
 sktime design principles in your project.
 """
 __version__: str = "0.6.1"

--- a/skbase/_exceptions.py
+++ b/skbase/_exceptions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # copyright: skbase developers, BSD-3-Clause License (see LICENSE file)
-# NotFittedError re-use code developed in scikit-learn. These elements
+# NotFittedError reuse code developed in scikit-learn. These elements
 # are copyrighted by the scikit-learn developers, BSD-3-Clause License. For
 # conditions see https://github.com/scikit-learn/scikit-learn/blob/main/COPYING
 """Custom exceptions used in ``skbase``."""

--- a/skbase/base/__init__.py
+++ b/skbase/base/__init__.py
@@ -3,7 +3,7 @@
 # copyright: skbase developers, BSD-3-Clause License (see LICENSE file)
 """:mod:`skbase.base` contains base classes for creating parametric objects.
 
-The included functionality makes it easy to re-use scikit-learn and
+The included functionality makes it easy to reuse scikit-learn and
 sktime design principles in your project.
 """
 from typing import List

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # copyright: skbase developers, BSD-3-Clause License (see LICENSE file)
-# Elements of BaseObject re-use code developed in scikit-learn. These elements
+# Elements of BaseObject reuse code developed in scikit-learn. These elements
 # are copyrighted by the scikit-learn developers, BSD-3-Clause License. For
 # conditions see https://github.com/scikit-learn/scikit-learn/blob/main/COPYING
 """Base class template for objects and fittable objects.
@@ -258,7 +258,7 @@ class BaseObject(_FlagManager):
 
     @classmethod
     def _get_init_signature(cls):
-        """Get class init sigature.
+        """Get class init signature.
 
         Useful in parameter inspection.
 
@@ -597,7 +597,7 @@ class BaseObject(_FlagManager):
 
         Notes
         -----
-        Changes object state by settting tag values in tag_dict as dynamic tags in self.
+        Changes object state by setting tag values in tag_dict as dynamic tags in self.
         """
         self._set_flags(flag_attr_name="_tags", **tag_dict)
 
@@ -1097,7 +1097,7 @@ class TagAliaserMixin:
 
         Notes
         -----
-        Changes object state by settting tag values in tag_dict as dynamic tags
+        Changes object state by setting tag values in tag_dict as dynamic tags
         in self.
         """
         self._deprecate_tag_warn(tag_dict.keys())

--- a/skbase/base/_meta.py
+++ b/skbase/base/_meta.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
 # copyright: skbase developers, BSD-3-Clause License (see LICENSE file)
-# BaseMetaObject and BaseMetaEstimator re-use code developed in scikit-learn and sktime.
+# BaseMetaObject and BaseMetaEstimator reuse code developed in scikit-learn and sktime.
 # These elements are copyrighted by the respective
 # scikit-learn developers (BSD-3-Clause License) and sktime (BSD-3-Clause) developers.
 # For conditions see licensing:
@@ -335,7 +335,7 @@ class _MetaObjectMixin:
             Named object tuple.
 
             - If `obj` was an object then returns (obj.__class__.__name__, obj).
-            - If `obj` was aleady a (name, object) tuple it is returned (a copy
+            - If `obj` was already a (name, object) tuple it is returned (a copy
               is returned if ``clone=True``).
         """
         if isinstance(obj, tuple) and len(obj) >= 2:
@@ -567,7 +567,7 @@ class _MetaObjectMixin:
         Parameters
         ----------
         other : BaseObject subclass
-            An object inheritting from `composite_class` or `base_class`, otherwise
+            An object inheriting from `composite_class` or `base_class`, otherwise
             `NotImplemented` is returned.
         base_class : BaseObject subclass
             Class assumed as base class for self and `other`. ,

--- a/skbase/base/_pretty_printing/_object_html_repr.py
+++ b/skbase/base/_pretty_printing/_object_html_repr.py
@@ -346,7 +346,7 @@ def _object_html_repr(base_object):
     Parameters
     ----------
     base_object : base object
-        The BaseObject or inheritting class to visualize.
+        The BaseObject or inheriting class to visualize.
 
     Returns
     -------

--- a/skbase/base/_tagmanager.py
+++ b/skbase/base/_tagmanager.py
@@ -165,7 +165,7 @@ class _FlagManager:
 
         Notes
         -----
-        Changes object state by settting flag values in flag_dict as dynamic flags
+        Changes object state by setting flag values in flag_dict as dynamic flags
         in self.
         """
         flag_update = deepcopy(flag_dict)

--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -115,7 +115,7 @@ def _is_ignored_module(
     returned for `module_name`-s `"bar.foo"`, `"foo"`, `"foo.bar"`,
     `"bar.foo.bar"`, etc.
 
-    Paramters
+    Parameters
     ---------
     module_name : str
         Name of the module.
@@ -304,7 +304,7 @@ def _import_module(
             loader.exec_module(imported_mod)
         exc = None
     except Exception as e:
-        # we store the exception so we can restore the stdout fisrt
+        # we store the exception so we can restore the stdout first
         exc = e
 
     # if we set up a text trap, restore it to the initial value
@@ -590,7 +590,7 @@ def get_package_metadata(
         following key:value pairs:
 
         - "path": str path to the submodule.
-        - "name": str name of hte submodule.
+        - "name": str name of the submodule.
         - "classes": dictionary with submodule's class names (keys) mapped to
           dictionaries with metadata about the class.
         - "functions": dictionary with function names (keys) mapped to
@@ -700,7 +700,7 @@ def all_objects(
 ):
     """Get a list of all objects in a package with name `package_name`.
 
-    This function crawls the package/module to retreive all classes
+    This function crawls the package/module to retrieve all classes
     that are descendents of BaseObject. By default it does this for the `skbase`
     package, but users can specify `package_name` or `path` to another project
     and `all_objects` will crawl and retrieve BaseObjects found in that project.

--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -116,7 +116,7 @@ def _is_ignored_module(
     `"bar.foo.bar"`, etc.
 
     Parameters
-    ---------
+    ----------
     module_name : str
         Name of the module.
     modules_to_ignore : str, list[str] or tuple[str]

--- a/skbase/lookup/tests/test_lookup.py
+++ b/skbase/lookup/tests/test_lookup.py
@@ -834,7 +834,7 @@ def test_get_return_tags():
 
 @pytest.mark.parametrize("as_dataframe", [True, False])
 @pytest.mark.parametrize("return_names", [True, False])
-@pytest.mark.parametrize("return_tags", [None, "A", ["A", "a_non_existant_tag"]])
+@pytest.mark.parametrize("return_tags", [None, "A", ["A", "a_non_existent_tag"]])
 @pytest.mark.parametrize("modules_to_ignore", ["tests", ("testing", "lookup"), None])
 @pytest.mark.parametrize("exclude_objects", [None, "Child", ["CompositionDummy"]])
 @pytest.mark.parametrize("suppress_import_stdout", [True, False])

--- a/skbase/lookup/tests/test_lookup.py
+++ b/skbase/lookup/tests/test_lookup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # copyright: skbase developers, BSD-3-Clause License (see LICENSE file)
 """Tests for skbase lookup functionality."""
-# Elements of the lookup tests re-use code developed in sktime. These elements
+# Elements of the lookup tests reuse code developed in sktime. These elements
 # are copyrighted by the sktime developers, BSD-3-Clause License. For
 # conditions see https://github.com/sktime/sktime/blob/main/LICENSE
 import importlib
@@ -158,7 +158,7 @@ def _check_package_metadata_result(results):
             isinstance(mod_metadata[k], str) for k in ("path", "name", "authors")
         ):
             return False
-        # Verify keys with bool values have bool valeus
+        # Verify keys with bool values have bool values
         if not all(
             isinstance(mod_metadata[k], bool)
             for k in (
@@ -309,7 +309,7 @@ def test_check_package_metadata_result(fixture_sample_package_metadata):
 
 
 def test_is_non_public_module(mod_names):
-    """Test _is_non_public_module correctly indentifies non-public modules."""
+    """Test _is_non_public_module correctly identifies non-public modules."""
     for mod in mod_names["public"]:
         assert _is_non_public_module(mod) is False
     for mod in mod_names["non_public"]:
@@ -328,7 +328,7 @@ def test_is_ignored_module(mod_names):
     for mod in mod_names["public"]:
         assert _is_ignored_module(mod) is False
 
-    # No modules should be flagged as ignored if the ignored moduels aren't encountered
+    # No modules should be flagged as ignored if the ignored modules aren't encountered
     modules_to_ignore = ("a_module_not_encountered",)
     for mod in mod_names["public"]:
         assert _is_ignored_module(mod, modules_to_ignore=modules_to_ignore) is False
@@ -355,7 +355,7 @@ def test_filter_by_class():
     # Test case when no class filter is applied (should always return True)
     assert _filter_by_class(CompositionDummy) is True
 
-    # Test case where a signle filter is applied
+    # Test case where a single filter is applied
     assert _filter_by_class(Parent, BaseObject) is True
     assert _filter_by_class(NotABaseObject, BaseObject) is False
     assert _filter_by_class(NotABaseObject, CompositionDummy) is False
@@ -391,7 +391,7 @@ def test_filter_by_tags():
     assert _filter_by_tags(Parent, {"A": "1", "B": 2}) is True
     # All keys in dict are in tag_filter, but at least 1 value doesn't match
     assert _filter_by_tags(Parent, {"A": 1, "B": 2}) is False
-    # Atleast 1 key in dict is not in tag_filter
+    # At least 1 key in dict is not in tag_filter
     assert _filter_by_tags(Parent, {"E": 1, "B": 2}) is False
 
     # Iterable tags should be all strings
@@ -413,7 +413,7 @@ def test_walk_returns_expected_format(fixture_skbase_root_path):
     def _test_walk_return(p):
         assert (
             isinstance(p, tuple) and len(p) == 3
-        ), "_walk shoul return tuple of length 3"
+        ), "_walk should return tuple of length 3"
         assert (
             isinstance(p[0], str)
             and isinstance(p[1], bool)

--- a/skbase/tests/mock_package/test_mock_package.py
+++ b/skbase/tests/mock_package/test_mock_package.py
@@ -52,7 +52,7 @@ class InheritsFromBaseObject(BaseObject):
 
 
 class AnotherClass(BaseObject):
-    """Another class inheritting from BaseObject."""
+    """Another class inheriting from BaseObject."""
 
 
 class NotABaseObject:
@@ -63,7 +63,7 @@ class NotABaseObject:
 
 
 class _NonPublicClass(BaseObject):
-    """A nonpublic class inheritting from BaseObject."""
+    """A nonpublic class inheriting from BaseObject."""
 
 
 MOCK_PACKAGE_OBJECTS = [

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -829,13 +829,13 @@ def test_set_params_raises_error_non_existent_param(
     # non-existing parameter in svc
     with pytest.raises(ValueError):
         fixture_class_parent_instance.set_params(
-            non_existant_param="updated param value"
+            non_existent_param="updated param value"
         )
 
     # non-existing parameter of composite
     composite = fixture_composition_dummy(foo=fixture_class_parent_instance, bar=84)
     with pytest.raises(ValueError):
-        composite.set_params(foo__non_existant_param=True)
+        composite.set_params(foo__non_existent_param=True)
 
 
 def test_set_params_raises_error_non_interface_composite(

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # copyright: skbase developers, BSD-3-Clause License (see LICENSE file)
-# Elements of these tests re-use code developed in scikit-learn. These elements
+# Elements of these tests reuse code developed in scikit-learn. These elements
 # are copyrighted by the scikit-learn developers, BSD-3-Clause License. For
 # conditions see https://github.com/scikit-learn/scikit-learn/blob/main/COPYING
 """Tests for BaseObject universal base class.
@@ -1203,7 +1203,7 @@ def test_has_implementation_of(
     """Test _has_implementation_of detects methods in class with overrides in mro."""
     # When the class overrides a parent classes method should return True
     assert fixture_class_child_instance._has_implementation_of("some_method")
-    # When class implements method first time it shoudl return False
+    # When class implements method first time it should return False
     assert not fixture_class_child_instance._has_implementation_of("some_other_method")
 
     # If the method is defined the first time in the parent class it should not

--- a/skbase/tests/test_baseestimator.py
+++ b/skbase/tests/test_baseestimator.py
@@ -6,7 +6,7 @@ tests in this module:
 
     test_baseestimator_inheritance - Test BaseEstimator inherits from BaseObject.
     test_has_is_fitted - Test that BaseEstimator has is_fitted interface.
-    test_has_check_is_fitted - Test that BaseEstimator has check_is_fitted inteface.
+    test_has_check_is_fitted - Test that BaseEstimator has check_is_fitted interface.
     test_is_fitted  - Test that is_fitted property returns _is_fitted as expected.
     test_check_is_fitted_raises_error_when_unfitted - Test check_is_fitted raises error.
 """

--- a/skbase/tests/test_meta.py
+++ b/skbase/tests/test_meta.py
@@ -66,7 +66,7 @@ def fixture_meta_estimator():
     return MetaEstimatorTester()
 
 
-def test_is_composit_returns_true(fixture_meta_object, fixture_meta_estimator):
+def test_is_composite_returns_true(fixture_meta_object, fixture_meta_estimator):
     """Test that `is_composite` method returns True."""
     msg = "`is_composite` should always be True for subclasses of "
     assert fixture_meta_object.is_composite() is True, msg + "`BaseMetaObject`."

--- a/skbase/utils/_check.py
+++ b/skbase/utils/_check.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # copyright: skbase developers, BSD-3-Clause License (see LICENSE file)
-# Elements of _is_scalar_nan re-use code developed in scikit-learn. These elements
+# Elements of _is_scalar_nan reuse code developed in scikit-learn. These elements
 # are copyrighted by the scikit-learn developers, BSD-3-Clause License. For
 # conditions see https://github.com/scikit-learn/scikit-learn/blob/main/COPYING
 

--- a/skbase/utils/_iter.py
+++ b/skbase/utils/_iter.py
@@ -90,7 +90,7 @@ def _format_seq_to_str(
     last_sep: Optional[str] = None,
     remove_type_text: bool = True,
 ) -> str:
-    """Format a sequence to a string of delimitted elements.
+    """Format a sequence to a string of delimited elements.
 
     This is useful to format sequences into a pretty printing format for
     creating error messages or warnings.

--- a/skbase/utils/deep_equals/_deep_equals.py
+++ b/skbase/utils/deep_equals/_deep_equals.py
@@ -303,8 +303,8 @@ def _fh_equals_plugin(x, y, return_msg=False, deep_equals=None):
 
     Parameters
     ----------
-    x: ForcastingHorizon
-    y: ForcastingHorizon
+    x: ForecastingHorizon
+    y: ForecastingHorizon
     return_msg : bool, optional, default=False
         whether to return informative message about what is not equal
 

--- a/skbase/utils/deep_equals/_deep_equals.py
+++ b/skbase/utils/deep_equals/_deep_equals.py
@@ -357,7 +357,7 @@ def deep_equals_custom(x, y, return_msg=False, plugins=None):
         entries must be functions with the signature:
         ``(x, y, return_msg: bool) -> return``
         where return is:
-        ``None``, if the plugin does not apply, otheriwse:
+        ``None``, if the plugin does not apply, otherwise:
         ``is_equal: bool`` if ``return_msg=False``,
         ``(is_equal: bool, msg: str)`` if return_msg=True.
         Plugins can have an additional argument ``deep_equals=None``

--- a/skbase/utils/tests/test_iter.py
+++ b/skbase/utils/tests/test_iter.py
@@ -8,7 +8,7 @@ tests in this module incdlue:
 - test_format_seq_to_str: verify that _format_seq_to_str outputs expected format.
 - test_format_seq_to_str_raises: verify _format_seq_to_str raises error on unexpected
   output.
-- test_scalar_to_seq_expected_output: verify that _scalar_to_seq returns exepcted
+- test_scalar_to_seq_expected_output: verify that _scalar_to_seq returns expected
   output.
 - test_scalar_to_seq_raises: verify that _scalar_to_seq raises error when an
   invalid value is provided for sequence_type parameter.

--- a/skbase/validate/_named_objects.py
+++ b/skbase/validate/_named_objects.py
@@ -27,7 +27,7 @@ __author__: List[str] = ["RNKuhns"]
 def _named_baseobject_error_msg(
     sequence_name: Optional[str] = None, allow_dict: bool = True
 ):
-    """Create error message for non-comformance with named BaseObject api."""
+    """Create error message for non-conformance with named BaseObject api."""
     name_str = f"{sequence_name}" if sequence_name is not None else "Input"
     allowed_types = "a sequence of (string name, BaseObject instance) tuples"
 
@@ -70,7 +70,7 @@ def is_named_object_tuple(
     >>> from skbase.base import BaseObject, BaseEstimator
     >>> from skbase.validate import is_named_object_tuple
 
-    Default checks for object to be an instance of BaseOBject
+    Default checks for object to be an instance of BaseObject
 
     >>> is_named_object_tuple(("Step 1", BaseObject()))
     True

--- a/skbase/validate/_named_objects.py
+++ b/skbase/validate/_named_objects.py
@@ -163,7 +163,7 @@ def is_sequence_named_objects(
     --------
     is_named_object_tuple :
         Indicate (True/False) if input follows the named object API format for
-        a single named object (e.g., tupe[str, expected class type]).
+        a single named object (e.g., tuple[str, expected class type]).
     check_sequence_named_objects :
         Validate input to see if it follows sequence of named objects API. An error
         is raised for input that does not conform to the API format.
@@ -346,7 +346,7 @@ def check_sequence_named_objects(
     --------
     is_named_object_tuple :
         Indicate (True/False) if input follows the named object API format for
-        a single named object (e.g., tupe[str, expected class type]).
+        a single named object (e.g., tuple[str, expected class type]).
     is_sequence_named_objects :
         Indicate (True/False) if an input sequence follows the named object API.
 

--- a/skbase/validate/_types.py
+++ b/skbase/validate/_types.py
@@ -306,13 +306,13 @@ def check_sequence(
         else:
             input_seq = _scalar_to_seq(input_seq, sequence_type=sequence_type)
 
-    is_valid_seqeunce = is_sequence(
+    is_valid_sequence = is_sequence(
         input_seq,
         sequence_type=sequence_type,
         element_type=element_type,
     )
     # Raise error is format is not expected.
-    if not is_valid_seqeunce:
+    if not is_valid_sequence:
         name_str = "Input sequence" if sequence_name is None else f"`{sequence_name}`"
         if sequence_type is None:
             seq_str = "a sequence"

--- a/skbase/validate/tests/test_iterable_named_objects.py
+++ b/skbase/validate/tests/test_iterable_named_objects.py
@@ -36,7 +36,7 @@ def test_is_named_object_tuple_output(
     fixture_estimator_instance, fixture_object_instance
 ):
     """Test is_named_object_tuple returns expected value."""
-    # Default checks for object to be an instance of BaseOBject
+    # Default checks for object to be an instance of BaseObject
     assert is_named_object_tuple(("Step 1", fixture_object_instance)) is True
     assert is_named_object_tuple(("Step 2", fixture_estimator_instance)) is True
 


### PR DESCRIPTION
Commands used:

1. `codespell --write-changes .`
2. `typos --locale en --write-changes`