### PR TITLE
[ENH] retain config after `clone`, add config to configure whether to clone config

### DIFF
--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -77,6 +77,7 @@ class BaseObject(_FlagManager):
         "display": "diagram",
         "print_changed_only": True,
         "check_clone": False,  # whether to execute validity checks in clone
+        "clone_config": True,  # clone config values (True) or use defaults (False)
     }
 
     def __init__(self):
@@ -156,6 +157,9 @@ class BaseObject(_FlagManager):
         """
         self_params = self.get_params(deep=False)
         self_clone = self._clone(self)
+
+        if self.get_config()["clone_config"]:
+            self._clone.set_config(**self.get_config())
 
         # if checking the clone is turned off, return now
         if not self.get_config()["check_clone"]:

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -931,6 +931,42 @@ def test_clone_raises_error_for_nonconforming_objects(
     #     obj_that_modifies.clone()
 
 
+@pytest.mark.parametrize("clone_config": [True, False])
+def test_config_after_clone_tags(clone_config):
+    """Test clone also clones config works as expected."""
+    from sklearn.base import clone
+
+    class TestClass(BaseObject):
+        _tags = {"some_tag": True, "another_tag": 37}
+        _config = {"check_clone": 0}
+
+    test_obj = TestClass()
+    test_obj.set_config(**{"check_clone": 42, "foo": "bar"})
+
+    if not clone_config:
+        # if clone_config config is set to False:
+        # config key check_clone should be default, 0
+        # the new config key foo should not be present
+        test_obj.set_config(**{"clone_config": False})
+        expected = 0
+    else:
+        # if clone_config config is set to True:
+        # config key check_clone should be 42, as set above
+        # the new config key foo should be present, as it has non default
+        expected = 42
+
+    test_obj_clone = clone(test_obj, clone_config=clone_config)
+
+    assert "check_clone" in test_obj_clone.get_config().keys()
+    assert test_obj_clone.get_config()["check_clone"] == expected
+
+    if clone_config:
+        assert "foo" in test_obj_clone.get_config().keys()
+        assert test_obj_clone.get_config()["foo"] == "bar"
+    else:
+        assert "foo" not in test_obj_clone.get_config().keys()
+
+
 @pytest.mark.skipif(
     not _check_soft_dependencies("sklearn", severity="none"),
     reason="skip test if sklearn is not available",


### PR DESCRIPTION
This PR ensures that set config fields are cloned, when using `clone`.

This behaviour can be reverted to current via a new config `clone_config`.

An important question: is the current behaviour close enough to being a bug, or very unexpected, as to not require deprecation, because we treat this as a bugfix?

Or is it an unexpected change, which would require deprecation?

An example would be, (a) first configuring an estimator via `set_config`, e.g., parallelization, (b) then wrapping it in a composite. This procedure would turn off an configs in the internally cloned estimator.
To me, this seems like a "bug" rather than "can be expected".