### PR TITLE
[ENH] retain config at `reset`, add tests for `set_config`, `get_config`

### DIFF
--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -127,6 +127,7 @@ class BaseObject(_FlagManager):
         """
         # retrieve parameters to copy them later
         params = self.get_params(deep=False)
+        config = self.get_config()
 
         # delete all object attributes in self
         attrs = [attr for attr in dir(self) if "__" not in attr]
@@ -137,6 +138,7 @@ class BaseObject(_FlagManager):
 
         # run init with a copy of parameters self had at the start
         self.__init__(**params)
+        self.set_config(**config)
 
         return self
 

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -1314,14 +1314,17 @@ def test_get_set_config():
 
     test_obj = _TestConfig(7)
 
-    # Test get_config
-    assert test_obj.get_config() == _TestConfig._config
+    expected_config_orig = BaseObject._config.copy()
+    expected_config_orig.update({"foo_config": 42, "bar": "a"})
 
-    # Test set_config
-    test_obj.set_config(foo_config=37)
+    # Test get_config
+    assert test_obj.get_config() == expected_config_orig
 
     expected_config = BaseObject._config.copy()
     expected_config.update({"foo_config": 37, "bar": "a"})
+
+    # Test set_config
+    test_obj.set_config(foo_config=37)
 
     assert test_obj.get_config() == expected_config
 

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -1297,3 +1297,31 @@ def test_eq_dunder():
     assert composite == composite_2
     assert composite != composite_3
     assert composite_2 != composite_3
+
+
+def test_get_set_config():
+    """Tests get_config and set_config methods."""
+
+    class _TestConfig(BaseObject):
+        _config = {"foo_config": 42, "bar": "a"}
+
+        clsvar = 210
+
+        def __init__(self, a, b=42):
+            self.a = a
+            self.b = b
+            self.c = 84
+
+    test_obj = _TestConfig(7)
+
+    # Test get_config
+    assert test_obj.get_config() == _TestConfig._config
+
+    # Test set_config
+    test_obj.set_config(foo_config=37)
+
+    assert test_obj.get_config() == {"foo_config": 37, "bar": "a"}
+
+    # test that reset does not reset config
+    test_obj.reset()
+    assert test_obj.get_config() == {"foo_config": 37, "bar": "a"}

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -1320,8 +1320,11 @@ def test_get_set_config():
     # Test set_config
     test_obj.set_config(foo_config=37)
 
-    assert test_obj.get_config() == {"foo_config": 37, "bar": "a"}
+    expected_config = BaseObject._config.copy()
+    expected_config.update({"foo_config": 37, "bar": "a"})
+
+    assert test_obj.get_config() == expected_config
 
     # test that reset does not reset config
     test_obj.reset()
-    assert test_obj.get_config() == {"foo_config": 37, "bar": "a"}
+    assert test_obj.get_config() == expected_config


### PR DESCRIPTION
This PR changes logic that ensures we retain config at `reset`.

Tests for `set_config`, `get_config` are also added to ensure coverage.