### PR TITLE
[BUG] fix `deep_equals` plugin for `pd.Index`

### DIFF
--- a/skbase/utils/deep_equals/_deep_equals.py
+++ b/skbase/utils/deep_equals/_deep_equals.py
@@ -488,7 +488,7 @@ def deep_equals_custom(x, y, return_msg=False, plugins=None):
         import numpy as np
 
     # deal with the case where != returns a vector
-    if numpy_available and np.any(x != y) or any(_coerce_list(x != y)):
+    if numpy_available and np.any(x != y) or np.any(_coerce_list(x != y)):
         return ret(False, f" !=, {x} != {y}")
 
     return ret(True, "")

--- a/skbase/utils/tests/test_deep_equals.py
+++ b/skbase/utils/tests/test_deep_equals.py
@@ -40,8 +40,8 @@ if _check_soft_dependencies("pandas", severity="none"):
         (np.array([1, 2, 4]), [pd.DataFrame({"a": [4, 2]})]),
         {"foo": [42], "bar": pd.Series([1, 2])},
         {"bar": [42], "foo": pd.Series([1, 2])},
-        pd.Index([1, 2, 3])
-        pd.Index([2, 3, 4])
+        pd.Index([1, 2, 3]),
+        pd.Index([2, 3, 4]),
     ]
 
     # nested DataFrame example

--- a/skbase/utils/tests/test_deep_equals.py
+++ b/skbase/utils/tests/test_deep_equals.py
@@ -40,6 +40,8 @@ if _check_soft_dependencies("pandas", severity="none"):
         (np.array([1, 2, 4]), [pd.DataFrame({"a": [4, 2]})]),
         {"foo": [42], "bar": pd.Series([1, 2])},
         {"bar": [42], "foo": pd.Series([1, 2])},
+        pd.Index([1, 2, 3])
+        pd.Index([2, 3, 4])
     ]
 
     # nested DataFrame example


### PR DESCRIPTION
The `deep_equals` plugin fo `pd.Index` resulted in failure when checking equality.

This PR fixes the bug, and adds test cases.