### PR TITLE
[BUG] fix `deep_equals` for `np.array` with `dtype="object"`

### DIFF
--- a/skbase/utils/deep_equals/_deep_equals.py
+++ b/skbase/utils/deep_equals/_deep_equals.py
@@ -134,7 +134,10 @@ def _numpy_equals_plugin(x, y, return_msg=False):
 
     if x.dtype != y.dtype:
         return ret(False, f".dtype, x.dtype = {x.dtype} != y.dtype = {y.dtype}")
-    return ret(np.array_equal(x, y, equal_nan=True), ".values")
+    if x.dtype in ["object", "str"]:
+        return ret(np.array_equal(x, y), ".values")
+    else:
+        return ret(np.array_equal(x, y, equal_nan=True), ".values")
 
 
 def _pandas_equals_plugin(x, y, return_msg=False, deep_equals=None):

--- a/skbase/utils/tests/test_deep_equals.py
+++ b/skbase/utils/tests/test_deep_equals.py
@@ -28,6 +28,9 @@ if _check_soft_dependencies("numpy", severity="none"):
         # in this case, the numpy equality plugin
         {"a": np.array([2, 3, 4]), "b": np.array([4, 3, 2])},
         [np.array([2, 3, 4]), np.array([4, 3, 2])],
+        # test case to cover branch re dtype and equal_nan
+        np.array([0.1, 1], dtype="object"),
+        np.array([0.2, 1], dtype="object"),
     ]
 
 if _check_soft_dependencies("pandas", severity="none"):


### PR DESCRIPTION
This PR fixes an unreported bug where `deep_equals` would break on `np.array` with `dtype="object"`, this is due to the `equal_nan=True` setting in `np.array_equal` which will lead to an exception if dtype="object"`.

Also includes test cases covering this.

Mirror of https://github.com/sktime/sktime/pull/5697 (duplicated prior to ongoing refactor)