### PR TITLE
[ENH] Random state handling, `set_random_state` method

### DIFF
--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -990,11 +990,11 @@ class BaseObject(_FlagManager):
         ----------
         random_state : int, RandomState instance or None, default=None
             Pseudo-random number generator to control the generation of the random
-            integers. Pass an int for reproducible output across multiple function calls.
+            integers. Pass int for reproducible output across multiple function calls.
 
         deep : bool, default=True
             Whether to set the random state in sub-estimators.
-            If False, will set only ``estimator``'s ``random_state`` parameter, if exists.
+            If False, will set only ``self``'s ``random_state`` parameter, if exists.
             If True, will set ``random_state`` parameters in sub-estimators as well.
 
         Returns

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -973,7 +973,7 @@ class BaseObject(_FlagManager):
             output["text/html"] = _object_html_repr(self)
         return output
 
-    def set_random_state(self, random_state, deep=True):
+    def set_random_state(self, random_state=None, deep=True):
         """Set random_state pseudo-random seed parameters for self.
 
         Finds ``random_state`` named parameters via ``self.get_params``,

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -973,6 +973,37 @@ class BaseObject(_FlagManager):
             output["text/html"] = _object_html_repr(self)
         return output
 
+    def set_random_state(self, random_state, deep=True):
+        """Set random_state pseudo-random seed parameters for self.
+
+        Finds ``random_state`` named parameters via ``self.get_params``,
+        and sets them to integers derived from ``random_state`` via ``set_params``.
+
+        Applies to ``random_state`` parameters in ``self`` always,
+        and all component estimators if and only if ``deep=True``.
+
+        Note: calls ``set_params`` even if ``self`` does not have a ``random_state``,
+        therefore ``set_random_state`` will reset any ``scikit-base`` estimator,
+        even those without a ``random_state`` parameter.
+
+        Parameters
+        ----------
+        random_state : int, RandomState instance or None, default=None
+            Pseudo-random number generator to control the generation of the random
+            integers. Pass an int for reproducible output across multiple function calls.
+
+        deep : bool, default=True
+            Whether to set the random state in sub-estimators.
+            If False, will set only ``estimator``'s ``random_state`` parameter, if exists.
+            If True, will set ``random_state`` parameters in sub-estimators as well.
+
+        Returns
+        -------
+        self : reference to self
+        """
+        from skbase.utils.random_state import set_random_state
+
+        return set_random_state(self, random_state=random_state, deep=deep)
 
 class TagAliaserMixin:
     """Mixin class for tag aliasing and deprecation of old tags.

--- a/skbase/tests/conftest.py
+++ b/skbase/tests/conftest.py
@@ -145,10 +145,13 @@ SKBASE_PUBLIC_FUNCTIONS_BY_MODULE = {
         "is_sequence_named_objects",
     ),
     "skbase.utils": (
+        "check_random_state",
         "deep_equals",
         "flatten",
         "is_flat",
         "make_strings_unique",
+        "sample_dependent_seed",
+        "set_random_state",
         "subset_dict_keys",
         "unflat_len",
         "unflatten",
@@ -163,6 +166,11 @@ SKBASE_PUBLIC_FUNCTIONS_BY_MODULE = {
     "skbase.utils._utils": ("subset_dict_keys",),
     "skbase.utils.deep_equals": ("deep_equals",),
     "skbase.utils.deep_equals._deep_equals": ("deep_equals", "deep_equals_custom"),
+    "skbase.utils.random_state": (
+        "check_random_state",
+        "sample_dependent_seed",
+        "set_random_state",
+    ),
     "skbase.validate._types": ("check_sequence", "check_type", "is_sequence"),
 }
 SKBASE_FUNCTIONS_BY_MODULE = SKBASE_PUBLIC_FUNCTIONS_BY_MODULE.copy()
@@ -230,6 +238,11 @@ SKBASE_FUNCTIONS_BY_MODULE.update(
         "skbase.utils.dependencies._dependencies": (
             "_check_soft_dependencies",
             "_check_python_version",
+        ),
+        "skbase.utils.random_state": (
+            "check_random_state",
+            "sample_dependent_seed",
+            "set_random_state",
         ),
         "skbase.validate._named_objects": (
             "check_sequence_named_objects",

--- a/skbase/tests/conftest.py
+++ b/skbase/tests/conftest.py
@@ -53,6 +53,7 @@ SKBASE_MODULES = (
     "skbase.utils.deep_equals._deep_equals",
     "skbase.utils.dependencies",
     "skbase.utils.dependencies._dependencies",
+    "skbase.utils.random_state",
     "skbase.validate",
     "skbase.validate._named_objects",
     "skbase.validate._types",
@@ -77,6 +78,7 @@ SKBASE_PUBLIC_MODULES = (
     "skbase.utils",
     "skbase.utils.deep_equals",
     "skbase.utils.dependencies",
+    "skbase.utils.random_state",
     "skbase.validate",
 )
 SKBASE_PUBLIC_CLASSES_BY_MODULE = {

--- a/skbase/utils/__init__.py
+++ b/skbase/utils/__init__.py
@@ -8,13 +8,21 @@ from skbase.utils._iter import make_strings_unique
 from skbase.utils._nested_iter import flatten, is_flat, unflat_len, unflatten
 from skbase.utils._utils import subset_dict_keys
 from skbase.utils.deep_equals import deep_equals
+from skbase.utils.random_state import (
+    check_random_state,
+    sample_dependent_seed,
+    set_random_state,
+)
 
 __author__: List[str] = ["RNKuhns", "fkiraly"]
 __all__: List[str] = [
+    "check_random_state",
     "deep_equals",
     "flatten",
     "is_flat",
     "make_strings_unique",
+    "sample_dependent_seed",
+    "set_random_state",
     "subset_dict_keys",
     "unflat_len",
     "unflatten",

--- a/skbase/utils/random_state.py
+++ b/skbase/utils/random_state.py
@@ -10,7 +10,7 @@ def set_random_state(estimator, random_state=0, deep=True):
     and sets them to integers derived from ``random_state`` via ``set_params``.
 
     Applies to ``random_state`` parameters in ``estimator`` always,
-    and all sub-estimators if and only if ``deep=True``.
+    and all component estimators if and only if ``deep=True``.
 
     Note: calls ``set_params`` even if ``estimator`` does not have a ``random_state``,
     therefore ``set_random_state`` will reset any ``scikit-base`` estimator,
@@ -33,7 +33,7 @@ def set_random_state(estimator, random_state=0, deep=True):
     Returns
     -------
     estimator : estimator
-        referece to ``estimator`` with state changed, random seed set
+        reference to ``estimator`` with state changed, random seed set
     """
     random_state = check_random_state(random_state)
 

--- a/skbase/utils/random_state.py
+++ b/skbase/utils/random_state.py
@@ -1,0 +1,123 @@
+"""Utilities for handling the random_state variable."""
+
+__author__ = ["fkiraly"]
+
+
+def set_random_state(estimator, random_state=0, deep=True):
+    """Set random_state pseudo-random seed parameters for an estimator.
+
+    Finds ``random_state`` named parameters via ``estimator.get_params``,
+    and sets them to integers derived from ``random_state`` via ``set_params``.
+
+    Applies to ``random_state`` parameters in ``estimator`` always,
+    and all sub-estimators if and only if ``deep=True``.
+
+    Note: calls ``set_params`` even if ``estimator`` does not have a ``random_state``,
+    therefore ``set_random_state`` will reset any ``scikit-base`` estimator,
+    even those without a ``random_state`` parameter.
+
+    Parameters
+    ----------
+    estimator : estimator supporting get_params, set_params
+        Estimator with potential randomness managed by random_state parameters.
+
+    random_state : int, RandomState instance or None, default=None
+        Pseudo-random number generator to control the generation of the random
+        integers. Pass an int for reproducible output across multiple function calls.
+
+    deep : bool, default=True
+        Whether to set the random state in sub-estimators.
+        If False, will set only ``estimator``'s ``random_state`` parameter, if exists.
+        If True, will set ``random_state`` parameters in sub-estimators as well.
+
+    Returns
+    -------
+    estimator : estimator
+        referece to ``estimator`` with state changed, random seed set
+    """
+    random_state = check_random_state(random_state)
+
+    keys = []
+    for key in sorted(estimator.get_params(deep=True)):
+        if key == "random_state":
+            keys.append(key)
+        if key.endswith("__random_state") and deep:
+            keys.append(key)
+
+    seeds = sample_dependent_seed(random_state, n_seeds=len(keys))
+    to_set = dict(zip(keys, seeds))
+
+    estimator.set_params(**to_set)
+    return estimator
+
+
+# This function is copied from scikit-learn (sklearn.utils)
+def check_random_state(seed):
+    """Turn seed into a np.random.RandomState instance.
+
+    Parameters
+    ----------
+    seed : None, int or instance of RandomState
+        If seed is None, return the RandomState singleton used by np.random.
+        If seed is an int, return a new RandomState instance seeded with seed.
+        If seed is already a RandomState instance, return it.
+        Otherwise raise ValueError.
+    """
+    import numbers
+    import numpy as np
+
+    if seed is None or seed is np.random:
+        return np.random.mtrand._rand
+    if isinstance(seed, numbers.Integral):
+        return np.random.RandomState(seed)
+    if isinstance(seed, np.random.RandomState):
+        return seed
+    raise ValueError(
+        "%r cannot be used to seed a numpy.random.RandomState instance" % seed
+    )
+
+
+def sample_dependent_seed(seed, n_seeds=None):
+    """Sample one or multiple dependent seeds from a given seed.
+
+    The sampled seeds are intended to be independent, pseudo-random uniform
+    from the set of 256-bit integers.
+
+    This is achieved by repeatedly hashing the seed using a cryptographic hash function,
+    ``hashlib.sha256`` for SHA-256, and converting the hash to an integer.
+
+    Parameters
+    ----------
+    seed : int (256-bit or less), bytes, or str coercible
+        The seed to sample from.
+    n_seeds : int, default=None
+        The number of seeds to sample. If None, a single seed is sampled and returned.
+        If an integer, a list of seeds of length ``n_seeds`` is sampled and returned.
+
+    Returns
+    -------
+    int or list of ints, all 256-bit
+        int if ``n_seeds`` is None, otherwise list of ints.
+        The sampled seed(s).
+    """
+    if n_seeds is not None:
+        seeds = []
+        for _ in range(n_seeds):
+            new_seed = sample_dependent_seed(seed)
+            seeds.append(new_seed)
+            seed = new_seed
+        return seeds
+
+    import hashlib
+
+    # Convert the base seed to bytes
+    seed_bytes = str(seed).encode('utf-8')
+
+    # Use a cryptographic hash function (SHA-256) to generate a secure hash
+    hash_object = hashlib.sha256(seed_bytes)
+    hashed_seed = hash_object.hexdigest()
+
+    # Convert the hashed seed to an integer
+    new_seed = int(hashed_seed, 16)
+
+    return new_seed

--- a/skbase/utils/random_state.py
+++ b/skbase/utils/random_state.py
@@ -4,7 +4,7 @@
 __author__ = ["fkiraly"]
 
 
-def set_random_state(estimator, random_state=0, deep=True):
+def set_random_state(estimator, random_state=None, deep=True):
     """Set random_state pseudo-random seed parameters for an estimator.
 
     Finds ``random_state`` named parameters via ``estimator.get_params``,

--- a/skbase/utils/tests/test_iter.py
+++ b/skbase/utils/tests/test_iter.py
@@ -3,7 +3,7 @@
 # copyright: skbase developers, BSD-3-Clause License (see LICENSE file)
 """Tests of the functionality for working with iterables.
 
-tests in this module incdlue:
+tests in this module include:
 
 - test_format_seq_to_str: verify that _format_seq_to_str outputs expected format.
 - test_format_seq_to_str_raises: verify _format_seq_to_str raises error on unexpected

--- a/skbase/utils/tests/test_nested_iter.py
+++ b/skbase/utils/tests/test_nested_iter.py
@@ -3,7 +3,7 @@
 # copyright: skbase developers, BSD-3-Clause License (see LICENSE file)
 """Tests of the functionality for working with iterables.
 
-tests in this module incdlue:
+tests in this module include:
 
 - test_remove_single
 - test_flatten

--- a/skbase/utils/tests/test_random_state.py
+++ b/skbase/utils/tests/test_random_state.py
@@ -31,9 +31,9 @@ def test_set_random_state(external, deep):
 
     def set_seed(obj):
         if external:
-            return set_random_state(obj, seed=42, deep=deep)
+            return set_random_state(obj, random_state=42, deep=deep)
         else:
-            return obj.set_random_state(seed=42, deep=deep)
+            return obj.set_random_state(random_state=42, deep=deep)
 
     class DummyDummy(BaseObject):
         """Has no random_state attribute."""

--- a/skbase/utils/tests/test_random_state.py
+++ b/skbase/utils/tests/test_random_state.py
@@ -48,7 +48,6 @@ def test_set_random_state(external, deep):
 
         def __init__(self, foo, random_state=None):
             self.foo = foo
-            self.foo_ = foo.clone()
             self.random_state = random_state
 
             super(SeedCompositionDummy, self).__init__()

--- a/skbase/utils/tests/test_random_state.py
+++ b/skbase/utils/tests/test_random_state.py
@@ -89,9 +89,9 @@ def test_set_random_state(external, deep, root_policy):
         assert composite1.get_params()["random_state"] != 42
     # the nested param depends on the deep argument
     if deep:
-        assert composite1.get_params()["foo__random_state"] != 42
+        assert composite1.get_params()["foo__random_state"] != 41
     else:
-        assert composite1.get_params()["foo__random_state"] == 42
+        assert composite1.get_params()["foo__random_state"] == 41
 
     # here we test two things:
     # does not break for seedless composites

--- a/skbase/utils/tests/test_random_state.py
+++ b/skbase/utils/tests/test_random_state.py
@@ -1,0 +1,84 @@
+# copyright: skbase developers, BSD-3-Clause License (see LICENSE file)
+"""Tests of random_seed related functionality."""
+import pytest
+
+from skbase.utils.random_state import sample_dependent_seed, set_random_state
+
+__author__ = ["fkiraly"]
+
+
+@pytest.mark.parametrize("seed", [1, 42, "foo"])
+@pytest.mark.parametrize("n_seeds", [None, 0, 1, 12])
+def test_sample_dependent_seed(seed, n_seeds):
+    """Test sample_dependent_seed returns expected output type."""
+    seeds = sample_dependent_seed(seed=seed, n_seeds=n_seeds)
+
+    if n_seeds is None:
+        assert isinstance(seeds, int)
+    else:
+        assert isinstance(seeds, list)
+        assert len(seeds) == n_seeds
+        assert all(isinstance(s, int) for s in seeds)
+
+
+@pytest.mark.parametrize("deep", [True, False])
+@pytest.mark.parametrize("external", [True, False])
+def test_set_random_state(external, deep):
+    """Test _format_seq_to_str returns expected output."""
+    # importing here to avoid circularity
+    from skbase.base import BaseObject
+
+    def set_seed(obj):
+        if external:
+            return set_random_state(obj, seed=42, deep=deep)
+        else:
+            return obj.set_random_state(seed=42, deep=deep)
+
+    class DummyDummy(BaseObject):
+        """Has no random_state attribute."""
+
+        def __init__(self, foo):
+            self.foo = foo
+
+            super(DummyDummy, self).__init__()
+
+    class SeedCompositionDummy(BaseObject):
+        """Potentially composite object, for testing."""
+
+        def __init__(self, foo, random_state=None):
+            self.foo = foo
+            self.foo_ = foo.clone()
+            self.random_state = random_state
+
+            super(SeedCompositionDummy, self).__init__()
+
+    simple = SeedCompositionDummy(foo=1, random_state=42)
+    seedless = DummyDummy(foo=42)
+    composite1 = SeedCompositionDummy(foo=simple, random_state=42)
+    composite2 = SeedCompositionDummy(foo=seedless, random_state=None) 
+
+    # in the simple case, the seed is set
+    # even though the seed in set_random_seed is 42, the set param will not be 42,
+    # because it is sampled from the set_random_seed seed 42
+    set_seed(simple)
+    assert simple.get_params()["random_state"] != 42
+
+    # this does not have a random_state attribute
+    # all we test is that it does not break
+    set_seed(seedless)
+
+    # in the composite case, the seed is set
+    # what happens to the nested param depends on the deep argument
+    set_seed(composite1)
+    assert composite1.get_params()["random_state"] != 42
+    if deep:
+        assert composite1.get_params()["foo__random_state"] != 42
+    else:
+        assert composite1.get_params()["foo__random_state"] == 42
+
+    # here we test two things:
+    # does not break for seedless composites
+    # behaviour if self.random_state is None
+    set_seed(composite2)
+    assert composite2.get_params()["random_state"] is not None
+    assert composite2.get_params()["random_state"] != 42

--- a/skbase/utils/tests/test_random_state.py
+++ b/skbase/utils/tests/test_random_state.py
@@ -54,8 +54,8 @@ def test_set_random_state(external, deep):
 
     simple = SeedCompositionDummy(foo=1, random_state=42)
     seedless = DummyDummy(foo=42)
-    composite1 = SeedCompositionDummy(foo=simple, random_state=42)
-    composite2 = SeedCompositionDummy(foo=seedless, random_state=None)
+    composite1 = SeedCompositionDummy(foo=simple.clone(), random_state=42)
+    composite2 = SeedCompositionDummy(foo=seedless.clone(), random_state=None)
 
     # in the simple case, the seed is set
     # even though the seed in set_random_seed is 42, the set param will not be 42,

--- a/skbase/utils/tests/test_random_state.py
+++ b/skbase/utils/tests/test_random_state.py
@@ -33,11 +33,11 @@ def test_set_random_state(external, deep, root_policy):
     def set_seed(obj):
         if external:
             return set_random_state(
-                obj, random_state=41, deep=deep, root_policy=root_policy
+                obj, random_state=42, deep=deep, root_policy=root_policy
             )
         else:
             return obj.set_random_state(
-                random_state=41, deep=deep, self_policy=root_policy
+                random_state=42, deep=deep, self_policy=root_policy
             )
 
     class DummyDummy(BaseObject):

--- a/skbase/utils/tests/test_utils.py
+++ b/skbase/utils/tests/test_utils.py
@@ -3,7 +3,7 @@
 # copyright: skbase developers, BSD-3-Clause License (see LICENSE file)
 """Tests of the functionality for miscellaneous utilities.
 
-tests in this module incdlue:
+tests in this module include:
 
 - test_subset_dict_keys_output: verify that subset_dict_keys outputs expected format.
 """


### PR DESCRIPTION
Adds a method `set_random_state` to estimators, and a utilities module related to random state handling.

The `set_random_state` method is recursive and creates dependent random seeds, similar to the `sklearn` utility of the same name.

In slight departure from `sklearn`, this is added as a method of `BaseObject`, similar to `clone`.