### PR TITLE
[ENH] `all_objects` `filter_tags` to function with list-of tags

### DIFF
--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -176,7 +176,10 @@ def _filter_by_tags(obj, tag_filter=None, as_dataframe=True):
 
         * key is tag name to sub-set on
         * value str or list of string are tag values
-        * condition is "key must be equal to value, or in set(value)"
+        * condition is "tag value at key must be equal to search value",
+          if search value, tag value are not iterable.
+          if on of search value, tag value, or oth are iterable: condition is
+          "at least one element of search value must be contained in tag value"
 
     Returns
     -------
@@ -740,6 +743,8 @@ def all_objects(
             to the value are returned.
           - If a dict key maps to multiple values (e.g., list) only classes with
             tag values in these values are returned.
+          - If tag values are iterable,
+            condition is "at least one search value is contained in tag values".
 
     exclude_objects: str or list[str], default=None
         Names of estimators to exclude.

--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -178,7 +178,7 @@ def _filter_by_tags(obj, tag_filter=None, as_dataframe=True):
         * value str or list of string are tag values
         * condition is "tag value at key must be equal to search value",
           if search value, tag value are not iterable.
-          if on of search value, tag value, or oth are iterable: condition is
+          if one of search value, tag value, or both, are lists: condition is
           "at least one element of search value must be contained in tag value"
 
     Returns

--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -221,10 +221,13 @@ def _filter_by_tags(obj, tag_filter=None, as_dataframe=True):
 
     cond_sat = True
 
-    for key, value in tag_filter.items():
-        if not isinstance(value, list):
-            value = [value]
-        cond_sat = cond_sat and obj.get_class_tag(key) in set(value)
+    for key, search_value in tag_filter.items():
+        if not isinstance(search_value, list):
+            search_value = [search_value]
+        tag_value = obj.get_class_tag(key)
+        if not isinstance(tag_value, list):
+            tag_value = [tag_value]
+        cond_sat = cond_sat and len(set(search_value).intersection(tag_value)) > 0
 
     return cond_sat
 


### PR DESCRIPTION
Currently, `all_objects` breaks if `filter_tags` is set and some tags in estimators are lists, as lists are unhashable.

This PR changes behaviour in the case of iterable tag value from raising an exception (unhashable list) to the condition that at least one search value is among the tag values.

Fixes first item in https://github.com/sktime/sktime/issues/5755