### PR TITLE
[ENH] estimator soft dependency check utilities

### DIFF
--- a/skbase/tests/conftest.py
+++ b/skbase/tests/conftest.py
@@ -205,6 +205,7 @@ SKBASE_FUNCTIONS_BY_MODULE.update(
         "skbase.utils.dependencies": (
             "_check_soft_dependencies",
             "_check_python_version",
+            "_check_estimator_deps",
         ),
         "skbase.utils._iter": (
             "_format_seq_to_str",
@@ -240,6 +241,7 @@ SKBASE_FUNCTIONS_BY_MODULE.update(
         "skbase.utils.dependencies._dependencies": (
             "_check_soft_dependencies",
             "_check_python_version",
+            "_check_estimator_deps",
         ),
         "skbase.utils.random_state": (
             "check_random_state",

--- a/skbase/utils/dependencies/__init__.py
+++ b/skbase/utils/dependencies/__init__.py
@@ -4,8 +4,13 @@
 """Utility functionality used through `skbase`."""
 
 from skbase.utils.dependencies._dependencies import (
+    _check_estimator_deps,
     _check_python_version,
     _check_soft_dependencies,
 )
 
-__all__ = ["_check_python_version", "_check_soft_dependencies"]
+__all__ = [
+    "_check_python_version",
+    "_check_soft_dependencies",
+    "_check_estimator_deps",
+]

--- a/skbase/utils/dependencies/_dependencies.py
+++ b/skbase/utils/dependencies/_dependencies.py
@@ -227,10 +227,14 @@ def _check_python_version(obj, package=None, msg=None, severity="error"):
     if sys_version in est_specifier:
         return True
     # now we know that est_version is not compatible with sys_version
+    if isclass(obj):
+        class_name = obj.__name__
+    else:
+        class_name = type(obj).__name__
 
     if not isinstance(msg, str):
         msg = (
-            f"{type(obj).__name__} requires python version to be {est_specifier},"
+            f"{class_name} requires python version to be {est_specifier},"
             f" but system python version is {sys.version}."
         )
 
@@ -248,6 +252,70 @@ def _check_python_version(obj, package=None, msg=None, severity="error"):
     else:
         raise RuntimeError(
             "Error in calling _check_python_version, severity "
-            f'argument must be "error", "warning", or "none", found {severity!r}.'
+            f'argument must be "error", "warning", or "none", found "{severity}".'
         )
     return True
+
+
+def _check_estimator_deps(obj, msg=None, severity="error"):
+    """Check if object/estimator's package & python requirements are met by python env.
+
+    Convenience wrapper around `_check_python_version` and `_check_soft_dependencies`,
+    checking against estimator tags `"python_version"`, `"python_dependencies"`.
+
+    Checks whether dependency requirements of `BaseObject`-s in `obj`
+    are satisfied by the current python environment.
+
+    Parameters
+    ----------
+    obj : `sktime` object, `BaseObject` descendant, or list/tuple thereof
+        object(s) that this function checks compatibility of, with the python env
+    msg : str, optional, default = default message (msg below)
+        error message to be returned in the `ModuleNotFoundError`, overrides default
+    severity : str, "error" (default), "warning", or "none"
+        behaviour for raising errors or warnings
+        "error" - raises a `ModuleNotFoundError` if environment is incompatible
+        "warning" - raises a warning if environment is incompatible
+            function returns False if environment is incompatible, otherwise True
+        "none" - does not raise exception or warning
+            function returns False if environment is incompatible, otherwise True
+
+    Returns
+    -------
+    compatible : bool, whether `obj` is compatible with python environment
+        False is returned only if no exception is raised by the function
+        checks for python version using the python_version tag of obj
+        checks for soft dependencies present using the python_dependencies tag of obj
+        if `obj` contains multiple `BaseObject`-s, checks whether all are compatible
+
+    Raises
+    ------
+    ModuleNotFoundError
+        User friendly error if obj has python_version tag that is
+        incompatible with the system python version.
+        Compatible python versions are determined by the "python_version" tag of obj.
+        User friendly error if obj has package dependencies that are not satisfied.
+        Packages are determined based on the "python_dependencies" tag of obj.
+    """
+    compatible = True
+
+    # if list or tuple, recurse & iterate over element, and return conjunction
+    if isinstance(obj, (list, tuple)):
+        for x in obj:
+            x_chk = _check_estimator_deps(x, msg=msg, severity=severity)
+            compatible = compatible and x_chk
+        return compatible
+
+    compatible = compatible and _check_python_version(obj, severity=severity)
+
+    pkg_deps = obj.get_class_tag("python_dependencies", None)
+    pck_alias = obj.get_class_tag("python_dependencies_alias", None)
+    if pkg_deps is not None and not isinstance(pkg_deps, list):
+        pkg_deps = [pkg_deps]
+    if pkg_deps is not None:
+        pkg_deps_ok = _check_soft_dependencies(
+            *pkg_deps, severity=severity, obj=obj, package_import_alias=pck_alias
+        )
+        compatible = compatible and pkg_deps_ok
+
+    return compatible

--- a/skbase/utils/dependencies/_dependencies.py
+++ b/skbase/utils/dependencies/_dependencies.py
@@ -276,7 +276,7 @@ def _check_python_version(obj, package=None, msg=None, severity="error"):
     else:
         raise RuntimeError(
             "Error in calling _check_python_version, severity "
-            f'argument must be "error", "warning", or "none", found "{severity}".'
+            f'argument must be "error", "warning", or "none", found {severity!r}.'
         )
     return True
 


### PR DESCRIPTION
This PR moves the `_check_estimator_deps` utility to `skbase`, from `sktime`.

It also makes minor updates to the other utilities in `skbase.utils.dependencies`.