### PR TITLE
[BUG] Fix deep equals pandas different length bug

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -72,7 +72,16 @@
           "maintenance",
           "test"
         ]
-      }
+      },
+      {
+        "login": "MBristle",
+        "name": "Mirko Bristle",
+        "avatar_url": "https://avatars.githubusercontent.com/MBristle",
+        "profile": "https://github.com/MBristle",
+        "contributions": [
+          "bug",
+        ]
+      },
   ],
   "projectName": "skbase",
   "projectOwner": "sktime",

--- a/skbase/utils/deep_equals/_deep_equals.py
+++ b/skbase/utils/deep_equals/_deep_equals.py
@@ -480,6 +480,12 @@ def deep_equals_custom(x, y, return_msg=False, plugins=None):
             if res is not None:
                 return res
 
+    # if the object x and y have a len() then compare of x and y lengths else continue
+    if hasattr(x, "__len__") and hasattr(y, "__len__"):
+        if len(x) != len(y):
+            return ret(False, f"Lengths must match to compare, "
+                              f"but x.len = {len(x)} != y.len = {len(y)}")
+
     # this if covers case where != is boolean
     # some types return a vector upon !=, this is covered in the next elif
     if isinstance(x == y, bool):

--- a/skbase/utils/tests/test_deep_equals.py
+++ b/skbase/utils/tests/test_deep_equals.py
@@ -23,6 +23,7 @@ if _check_soft_dependencies("numpy", severity="none"):
     EXAMPLES += [
         np.array([2, 3, 4]),
         np.array([2, 4, 5]),
+        np.array([2, 4, 5, 4]),
         np.nan,
         # these cases test that plugins are passed to recursions
         # in this case, the numpy equality plugin
@@ -31,6 +32,7 @@ if _check_soft_dependencies("numpy", severity="none"):
         # test case to cover branch re dtype and equal_nan
         np.array([0.1, 1], dtype="object"),
         np.array([0.2, 1], dtype="object"),
+        np.array([0.2, 1, 4], dtype="object"),
     ]
 
 if _check_soft_dependencies("pandas", severity="none"):
@@ -39,12 +41,14 @@ if _check_soft_dependencies("pandas", severity="none"):
     EXAMPLES += [
         pd.DataFrame({"a": [4, 2]}),
         pd.DataFrame({"a": [4, 3]}),
+        pd.DataFrame({"a": [4, 3, 5]}),
         pd.DataFrame({"a": ["4", "3"]}),
         (np.array([1, 2, 4]), [pd.DataFrame({"a": [4, 2]})]),
         {"foo": [42], "bar": pd.Series([1, 2])},
         {"bar": [42], "foo": pd.Series([1, 2])},
         pd.Index([1, 2, 3]),
         pd.Index([2, 3, 4]),
+        pd.Index([2, 3, 4, 6]),
     ]
 
     # nested DataFrame example


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skbase.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
fixes the issue discussed in https://github.com/sktime/sktime/issues/5915 


#### What does this implement/fix? Could you explain your changes?
added a length comparison to the deep_equals_custom method

#### Does your contribution introduce a new dependency? If yes, which one?

no

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development.
You can guide the reviews to focus on the parts that are ready for their comments.
We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Any other comments?
related to sktime as the code lives in both places. Hence, we need to fix the code in both places. 

#### PR checklist

##### For all contributions
- [ x] I've reviewed the project documentation on [contributing](https://skbase.readthedocs.io/en/latest/contribute.html)
- [ x] I've added myself to the [list of contributors](https://github.com/sktime/skbase/blob/main/.all-contributorsrc).
- [ x] The PR title starts with either [ENH], [CI/CD], [MNT], [DOC], or [BUG] indicating whether
  the PR topic is related to enhancement, CI/CD, maintenance, documentation, or a bug.

##### For code contributions
- [ x] Unit tests have been added covering code functionality
- [ x] Appropriate docstrings have been added (see [documentation standards](https://skbase.readthedocs.io/en/latest/contribute/development/developer_guide/creating_docs.html))
- [ ] New public functionality has been added to the API Reference


<!--
Thanks for contributing!
-->
