### PR TITLE
[MNT] remove unnecessary CI triggers for release branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,9 @@ on:
       - 'docs/**'
     branches:
       - main
-      - 'release**'
   pull_request:
     branches:
       - main
-      - 'release**'
     paths-ignore:
       - 'docs/**'
     types: [opened, synchronize]


### PR DESCRIPTION
Current CI triggers push/pull CI also on release branches, this is removed by this PR.

Why: the trigger for release branches is unnecessary, as we currently merge directly to `main` and cut release by tag, rather than by merging release branch to `main` - so the CI element can be removed.