### PR TITLE
[BUG] preserve exception type raised by `get_test_params`

### DIFF
--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -696,10 +696,10 @@ class BaseObject(_FlagManager):
         try:
             return cls(**params)
         except Exception as e:
-            raise ValueError(
+            raise type(e)(
                 f"Error in {cls.__name__}.get_test_params, "
                 "return must be valid param dict for class, or list thereof, "
-                "but attempted contsruction raised a exception. "
+                "but attempted construction raised a exception. "
                 f"Problematic parameter set: {params}. Exception raised: {e}"
             ) from e
 


### PR DESCRIPTION
PR #239 changes the type of exception raised by `get_test_params` to `ValueError`, which is an unintended side effect of the imprroved error feedback.

This can lead to breakage in exception handling, e.g., in `sktime` tests for exception handling on top.

This PR ensures the type of exception is preserved.