### PR TITLE
[BUG] fix `deep_equals` on objects which have `__len__` but `len(obj)` causes exception

### DIFF
--- a/skbase/tests/conftest.py
+++ b/skbase/tests/conftest.py
@@ -237,6 +237,7 @@ SKBASE_FUNCTIONS_BY_MODULE.update(
             "_numpy_equals_plugin",
             "_pandas_equals",
             "_pandas_equals_plugin",
+            "_safe_len",
             "_softdep_available",
             "_tuple_equals",
             "deep_equals",

--- a/skbase/utils/deep_equals/_deep_equals.py
+++ b/skbase/utils/deep_equals/_deep_equals.py
@@ -481,12 +481,11 @@ def deep_equals_custom(x, y, return_msg=False, plugins=None):
                 return res
 
     # if the object x and y have a len() then compare of x and y lengths else continue
-    if hasattr(x, "__len__") and hasattr(y, "__len__"):
-        if len(x) != len(y):
-            return ret(
-                False,
-                f".len, x.len = {len(x)} != y.len = {len(y)}",
-            )
+    if _safe_len(x) != _safe_len(y):
+        return ret(
+            False,
+            f".len, x.len = {len(x)} != y.len = {len(y)}",
+        )
 
     # this if covers case where != is boolean
     # some types return a vector upon !=, this is covered in the next elif
@@ -503,3 +502,14 @@ def deep_equals_custom(x, y, return_msg=False, plugins=None):
         return ret(False, f" !=, {x} != {y}")
 
     return ret(True, "")
+
+
+def _safe_len(x):
+    """Return length of x if len(x) does not result in exception, else -1."""
+    if hasattr(x, "__len__"):
+        try:
+            x_len = len(x)
+            return x_len
+        except Exception:
+            return -1
+    return -1

--- a/skbase/utils/dependencies/_dependencies.py
+++ b/skbase/utils/dependencies/_dependencies.py
@@ -27,7 +27,7 @@ def _check_soft_dependencies(
     ----------
     packages : str or list/tuple of str, or length-1-tuple containing list/tuple of str
         str should be package names and/or package version specifications to check.
-        Each str must be a PEP 440 compatibe specifier string, for a single package.
+        Each str must be a PEP 440 compatible specifier string, for a single package.
         For instance, the PEP 440 compatible package name such as "pandas";
         or a package requirement specifier string such as "pandas>1.2.3".
         arg can be str, kwargs tuple, or tuple/list of str, following calls are valid:

--- a/skbase/utils/tests/test_deep_equals.py
+++ b/skbase/utils/tests/test_deep_equals.py
@@ -64,6 +64,14 @@ if _check_soft_dependencies("pandas", severity="none"):
 
     EXAMPLES += [X]
 
+if _check_soft_dependencies(
+    "scikit-learn", package_import_alias={"scikit-learn": "sklearn"}, severity="none"
+):
+    from sklearn.ensemble import RandomForestRegressor
+
+    EXAMPLES += [RandomForestRegressor()]
+    EXAMPLES += [RandomForestRegressor(n_estimators=42)]
+
 
 @pytest.mark.parametrize("fixture", EXAMPLES)
 def test_deep_equals_positive(fixture):

--- a/skbase/utils/tests/test_deep_equals.py
+++ b/skbase/utils/tests/test_deep_equals.py
@@ -120,7 +120,7 @@ def copy_except_if_sklearn(obj):
     ):
         return deepcopy(obj)
     else:
-        from sklearn import BaseEstimator
+        from sklearn.base import BaseEstimator
 
         if isinstance(obj, BaseEstimator):
             return obj


### PR DESCRIPTION
Fixes #302 by using a safe way to read length.

Also adds the MRE #302 as a test case, to cover this edge case.

FYI @MBristle, and we thought the fix was easy...