### PR TITLE
[BUG] safer comparison in `deep_equals` if `np.any(x != y)` does not result in boolean

### DIFF
--- a/skbase/tests/conftest.py
+++ b/skbase/tests/conftest.py
@@ -237,6 +237,7 @@ SKBASE_FUNCTIONS_BY_MODULE.update(
             "_numpy_equals_plugin",
             "_pandas_equals",
             "_pandas_equals_plugin",
+            "_save_any_unequal",
             "_safe_len",
             "_softdep_available",
             "_tuple_equals",

--- a/skbase/tests/conftest.py
+++ b/skbase/tests/conftest.py
@@ -237,7 +237,7 @@ SKBASE_FUNCTIONS_BY_MODULE.update(
             "_numpy_equals_plugin",
             "_pandas_equals",
             "_pandas_equals_plugin",
-            "_save_any_unequal",
+            "_safe_any_unequal",
             "_safe_len",
             "_softdep_available",
             "_tuple_equals",

--- a/skbase/utils/deep_equals/_deep_equals.py
+++ b/skbase/utils/deep_equals/_deep_equals.py
@@ -539,7 +539,7 @@ def _safe_any_unequal(x, y):
 
     try:
         any_un = np.any(x != y) or np.any(_coerce_list(x != y))
-        if isinstance(any_un, bool):
+        if isinstance(any_un, bool) or any_un.dtype == "bool":
             return any_un
         else:
             return False

--- a/skbase/utils/deep_equals/_deep_equals.py
+++ b/skbase/utils/deep_equals/_deep_equals.py
@@ -511,7 +511,7 @@ def deep_equals_custom(x, y, return_msg=False, plugins=None):
 
 
 def _safe_any_unequal(x, y):
-    """Return whether any element of x != y, or False on exception.
+    """Return whether any of x != y, if != results in iterable, False on exception.
 
     Written very defensively to avoid exceptions, as exceptions may be raised
     since any(x != y) or the safer np.any(x != y) may not be boolean,


### PR DESCRIPTION
This PR replaces a comparison in `deep_equals` with a defensive alternative.

Namely, `np.any(x != y)` and similar expressions are assumed to result in a boolean, but this may be false in pathological cases, e.g., nested lists or nested numpy arrays with non-numpy objects inside.

The defensive replacement should catch any case where the expressions assumed boolean are not boolean, and in that case have the same effect as skipping the test.

If `deep_equals` cannot determine equality via the condition, it returns `True` at the end, so when in doubt objects and estimators are deemed to comply with `sklearn` or `sktime` contracts, in dependent tests.