### PR TITLE
[BUG] fix permanently muted `stdout` after `all_objects` call

### DIFF
--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -1020,11 +1020,13 @@ class StdoutMute:
         self.active = active
 
     def __enter__(self):
+        """Context manager entry point."""
         if self.active:
             self._stdout = sys.stdout
             sys.stdout = io.StringIO()
 
     def __exit__(self, type, value, traceback):
+        """Context manager exit point."""
         if self. active:
             sys.stdout = self._stdout
 

--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -1046,3 +1046,5 @@ class StdoutMute:
 
             # all other exceptions are raised
             return False
+        # if no exception was raised, return True to indicate successful exit
+        return True

--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -1026,6 +1026,7 @@ class StdoutMute:
             sys.stdout = io.StringIO()
 
     def __exit__(self, type, value, traceback):
+        """Context manager exit point."""
         if self.active:
             sys.stdout = self._stdout
 

--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -295,7 +295,7 @@ def _import_module(
 
     # if suppress_import_stdout:
     # setup text trap, import
-    with StdoutMutex(active=suppress_import_stdout):
+    with StdoutMute(active=suppress_import_stdout):
         if isinstance(module, str):
             imported_mod = importlib.import_module(module)
         elif isinstance(module, importlib.machinery.SourceFileLoader):
@@ -830,7 +830,7 @@ def all_objects(
                 continue
 
             # setup text trap, import, then restore
-            with StdoutMutex(active=suppress_import_stdout):
+            with StdoutMute(active=suppress_import_stdout):
                 if suppress_import_stdout:
                     module = importlib.import_module(module_name)
                 else:
@@ -999,7 +999,7 @@ def _make_dataframe(all_objects, columns):
     return pd.DataFrame(all_objects, columns=columns)
 
 
-class StdoutMutex:
+class StdoutMute:
     """A context manager to suppress stdout.
 
     This class is used to suppress stdout when importing modules.

--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -1027,7 +1027,7 @@ class StdoutMute:
             self._stdout = sys.stdout
             sys.stdout = io.StringIO()
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, type, value, traceback):  # noqa: A002
         """Context manager exit point."""
         # restore stdout if active
         # if not active, nothing needs to be done, since stdout was not replaced

--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -1021,12 +1021,16 @@ class StdoutMute:
 
     def __enter__(self):
         """Context manager entry point."""
+        # capture stdout if active
+        # store the original stdout so it can be restored in __exit__
         if self.active:
             self._stdout = sys.stdout
             sys.stdout = io.StringIO()
 
     def __exit__(self, type, value, traceback):
         """Context manager exit point."""
+        # restore stdout if active
+        # if not active, nothing needs to be done, since stdout was not replaced
         if self.active:
             sys.stdout = self._stdout
 

--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -1047,4 +1047,5 @@ class StdoutMute:
             # all other exceptions are raised
             return False
         # if no exception was raised, return True to indicate successful exit
+        # return statement not needed as type was None, but included for clarity
         return True

--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -1003,6 +1003,17 @@ class StdoutMute:
     """A context manager to suppress stdout.
 
     This class is used to suppress stdout when importing modules.
+
+    Also downgrades any ModuleNotFoundError to a warning if the error message
+    contains the substring "soft dependency".
+
+    Parameters
+    ----------
+    active : bool, default=True
+        Whether to suppress stdout or not.
+        If True, stdout is suppressed.
+        If False, stdout is not suppressed, and the context manager does nothing
+        except catch and suppress ModuleNotFoundError.
     """
 
     def __init__(self, active=True):

--- a/skbase/lookup/tests/test_lookup.py
+++ b/skbase/lookup/tests/test_lookup.py
@@ -6,6 +6,7 @@
 # conditions see https://github.com/sktime/sktime/blob/main/LICENSE
 import importlib
 import pathlib
+import sys
 from copy import deepcopy
 from types import ModuleType
 from typing import List
@@ -848,7 +849,14 @@ def test_all_objects_returns_expected_types(
     exclude_objects,
     suppress_import_stdout,
 ):
-    """Test that all_objects return argument has correct type."""
+    """Test that all_objects return argument has correct type.
+
+    Also tested: sys.stdout is unchanged after function call, see bug #327.
+    """
+    # we will check later that sys.stdout is unchanged
+    initial_stdout = sys.stdout
+
+    # call all_objects
     objs = all_objects(
         package_name="skbase",
         exclude_objects=exclude_objects,
@@ -858,6 +866,11 @@ def test_all_objects_returns_expected_types(
         modules_to_ignore=modules_to_ignore,
         suppress_import_stdout=suppress_import_stdout,
     )
+
+    # verify sys.stdout is unchanged
+    assert sys.stdout == initial_stdout
+
+    # verify output has expected types
     if isinstance(modules_to_ignore, str):
         modules_to_ignore = (modules_to_ignore,)
     if (

--- a/skbase/tests/conftest.py
+++ b/skbase/tests/conftest.py
@@ -99,7 +99,7 @@ SKBASE_PUBLIC_CLASSES_BY_MODULE = {
         "BaseMetaEstimatorMixin",
     ),
     "skbase.base._pretty_printing._pprint": ("KeyValTuple", "KeyValTupleParam"),
-    "skbase.lookup._lookup": (),
+    "skbase.lookup._lookup": ("StdoutMute"),
     "skbase.testing": ("BaseFixtureGenerator", "QuickTester", "TestAllObjects"),
     "skbase.testing.test_all_objects": (
         "BaseFixtureGenerator",

--- a/skbase/tests/conftest.py
+++ b/skbase/tests/conftest.py
@@ -99,7 +99,7 @@ SKBASE_PUBLIC_CLASSES_BY_MODULE = {
         "BaseMetaEstimatorMixin",
     ),
     "skbase.base._pretty_printing._pprint": ("KeyValTuple", "KeyValTupleParam"),
-    "skbase.lookup._lookup": ("StdoutMute"),
+    "skbase.lookup._lookup": ("StdoutMute",),
     "skbase.testing": ("BaseFixtureGenerator", "QuickTester", "TestAllObjects"),
     "skbase.testing.test_all_objects": (
         "BaseFixtureGenerator",


### PR DESCRIPTION
This fixes https://github.com/sktime/skbase/issues/327, which caused a permanently muted `stdout` after `all_objects` call.

The bug was due to the `sys.stdout` not being properly reset after muting, in one of two instances where this was done.

This PR also replaces both instances with a muter context manager - the implementation of the muting was a bit brittle, relying on manual try/except and temp stdout handling which is risky.

Includes a test that the `sys.stdout` is indeed unchanged.