### PR TITLE
[ENH] `all_objects` retrieval filtered by regex applied to tag values, deprecation of "has tag" condition in favour of "tag is True"

### DIFF
--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -226,7 +226,7 @@ def _filter_by_tags(obj, tag_filter=None, as_dataframe=True):
     # case: tag_filter is string
     if isinstance(tag_filter, str):
         # todo 0.9.0: reomove this warning
-        warnings.warn(warn_msg, FutureWarning)
+        warnings.warn(warn_msg, DeprecationWarning, stacklevel=2)
         # todo 0.9.0: replace this line
         return tag_filter in klass_tags
         # by this line
@@ -238,7 +238,7 @@ def _filter_by_tags(obj, tag_filter=None, as_dataframe=True):
         if not all(isinstance(t, str) for t in tag_filter):
             raise ValueError(f"{type_msg} {tag_filter}")
         # todo 0.9.0: reomove this warning
-        warnings.warn(warn_msg, FutureWarning)
+        warnings.warn(warn_msg, DeprecationWarning, stacklevel=2)
         # todo 0.9.0: replace this line
         return all(tag in klass_tags for tag in tag_filter)
         # by this line

--- a/skbase/lookup/_lookup.py
+++ b/skbase/lookup/_lookup.py
@@ -255,8 +255,9 @@ def _filter_by_tags(obj, tag_filter=None, as_dataframe=True):
         if not isinstance(search_value, list):
             search_value = [search_value]
 
-        search_value_re = [s for s in search_value if isinstance(s, re.Pattern)]
-        search_value_str = [s for s in search_value if not isinstance(s, re.Pattern)]
+        # split search_value into strings/other and re.Pattern
+        search_re = [s for s in search_value if isinstance(s, re.Pattern)]
+        search_str = [s for s in search_value if not isinstance(s, re.Pattern)]
 
         tag_value = obj.get_class_tag(key)
         if not isinstance(tag_value, list):
@@ -264,8 +265,8 @@ def _filter_by_tags(obj, tag_filter=None, as_dataframe=True):
 
         # search value matches tag value iff
         # at least one element of search value matches at least one element of tag value
-        str_match = len(set(search_value_str).intersection(tag_value)) > 0
-        re_match = any(s.fullmatch(tag) for s in search_value_re for tag in tag_value)
+        str_match = len(set(search_str).intersection(tag_value)) > 0
+        re_match = any(s.fullmatch(str(tag)) for s in search_re for tag in tag_value)
         match = str_match or re_match
 
         cond_sat = cond_sat and match

--- a/skbase/lookup/tests/test_lookup.py
+++ b/skbase/lookup/tests/test_lookup.py
@@ -395,15 +395,15 @@ def test_filter_by_tags():
     assert _filter_by_tags(Parent, {"E": 1, "B": 2}) is False
 
     # Iterable tags should be all strings
-    with pytest.raises(ValueError, match=r"tag_filter"):
+    with pytest.raises(ValueError, match=r"filter_tags"):
         assert _filter_by_tags(Parent, ("A", "B", 3))
 
     # Tags that aren't iterable have to be strings
-    with pytest.raises(TypeError, match=r"tag_filter"):
+    with pytest.raises(TypeError, match=r"filter_tags"):
         assert _filter_by_tags(Parent, 7.0)
 
     # Dictionary tags should have string keys
-    with pytest.raises(ValueError, match=r"tag_filter"):
+    with pytest.raises(ValueError, match=r"filter_tags"):
         assert _filter_by_tags(Parent, {7: 11})
 
 

--- a/skbase/lookup/tests/test_lookup.py
+++ b/skbase/lookup/tests/test_lookup.py
@@ -42,7 +42,7 @@ from skbase.tests.mock_package.test_mock_package import (
     NotABaseObject,
 )
 
-__author__: List[str] = ["RNKuhns"]
+__author__: List[str] = ["RNKuhns", "fkiraly"]
 __all__: List[str] = []
 
 
@@ -982,6 +982,43 @@ def test_all_object_tag_filter(tag_filter):
         assert unfiltered_classes == filtered_classes
     else:
         assert len(unfiltered_classes) > len(filtered_classes)
+
+
+def test_all_object_tag_filter_regex():
+    """Test all_objects filters by tag as expected, when using regex."""
+    import re
+
+    # search for class where "A" has at least one 1, and "C" has "23" in the tag value
+    # this sohuld find Parent but not Child
+    filter_tags = {"A": re.compile(r"^(?=.*1).*$"), "C": re.compile(r".+23.+")}
+
+    # Results applying filter
+    objs = all_objects(
+        package_name="skbase",
+        return_names=True,
+        as_dataframe=True,
+        return_tags=None,
+        filter_tags=filter_tags,
+    )
+    filtered_classes = objs.iloc[:, 1].tolist()
+    # Verify filtered results have right output type
+    _check_all_object_output_types(
+        objs, as_dataframe=True, return_names=True, return_tags=None
+    )
+
+    # Results without filter
+    objs = all_objects(
+        package_name="skbase",
+        return_names=True,
+        as_dataframe=True,
+        return_tags=None,
+    )
+    unfiltered_classes = objs.iloc[:, 1].tolist()
+
+    # as stated above, we should find only Parent (and not Child)
+    assert len(unfiltered_classes) > len(filtered_classes)
+    names = [kls.__name__ for kls in filtered_classes]
+    assert "Parent" in names
 
 
 @pytest.mark.parametrize("class_lookup", [{"base_object": BaseObject}])


### PR DESCRIPTION
This PR closes https://github.com/sktime/skbase/issues/326.

It implements:

* functionality for `all_objects` to retrieve classes by specifying regex for tag values
* deprecation warnings for `str` and `list of str` condition meaning to change from "has tag" to "tag is True" meaning, from 0.9.0 release onwards
    * the deprecation message includes instructions on how to retain current behaviour - this uses the regex specification

This PR also improves formatting of the docstring of `all_objects`.