### PR TITLE
[ENH] option to return `BaseObject.get_param_names` in the same order as in the `__init__`

### DIFF
--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -206,15 +206,15 @@ class BaseObject(_FlagManager):
                 )
         return parameters
 
-    # todo 0.10.0: changed sorted default to False
+    # todo 0.10.0: changed sort default to False
     # update docstring, and remove warning
     @classmethod
-    def get_param_names(cls, sorted=None):
+    def get_param_names(cls, sort=None):
         """Get object's parameter names.
 
         Parameters
         ----------
-        sorted : bool, default=True
+        sort : bool, default=True
             Whether to return the parameter names sorted in alphabetical order (True),
             or in the order they appear in the class ``__init__`` (False).
 
@@ -222,11 +222,11 @@ class BaseObject(_FlagManager):
         -------
         param_names: list[str]
             List of parameter names of cls.
-            If ``sorted=False``, in same order as they appear in the class ``__init__``.
-            If ``sorted=True``, alphabetically ordered.
+            If ``sort=False``, in same order as they appear in the class ``__init__``.
+            If ``sort=True``, alphabetically ordered.
         """
-        if sorted is None:
-            sorted = True
+        if sort is None:
+            sort = True
             warn(
                 "In scikit-base BaseObject.get_param_names, the default of parameter"
                 " 'sorted' will change from True to False in 0.10.0. "
@@ -234,7 +234,7 @@ class BaseObject(_FlagManager):
                 " in the order they appear in the class __init__, "
                 "rather than alphabetically ordered. "
                 "To retain previous behaviour in direct calls, "
-                "set 'sorted=True'. To silence this warning, set 'sorted' to "
+                "set 'sort=True'. To silence this warning, set 'sorted' to "
                 "either True or False.",
                 FutureWarning,
             )
@@ -613,7 +613,7 @@ class BaseObject(_FlagManager):
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
         params_with_defaults = set(cls.get_param_defaults().keys())
-        all_params = set(cls.get_param_names(sorted=False))
+        all_params = set(cls.get_param_names(sort=False))
         params_without_defaults = all_params - params_with_defaults
 
         # if non-default parameters are required, but none have been found, raise error

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -206,7 +206,7 @@ class BaseObject(_FlagManager):
         return parameters
 
     @classmethod
-    def get_param_names(cls, sort=None):
+    def get_param_names(cls, sort=True):
         """Get object's parameter names.
 
         Parameters

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -58,7 +58,6 @@ import warnings
 from collections import defaultdict
 from copy import deepcopy
 from typing import List
-from warnings import warn
 
 from skbase._exceptions import NotFittedError
 from skbase.base._pretty_printing._object_html_repr import _object_html_repr
@@ -227,21 +226,10 @@ class BaseObject(_FlagManager):
         """
         if sort is None:
             sort = True
-            warn(
-                "In scikit-base BaseObject.get_param_names, the default of parameter"
-                " 'sorted' will change from True to False in 0.10.0. "
-                "This will change the order of the output, returning the parameters"
-                " in the order they appear in the class __init__, "
-                "rather than alphabetically ordered. "
-                "To retain previous behaviour in direct calls, "
-                "set 'sort=True'. To silence this warning, set 'sorted' to "
-                "either True or False.",
-                FutureWarning,
-            )
 
         parameters = cls._get_init_signature()
         param_names = [p.name for p in parameters]
-        if sorted:
+        if sort:
             param_names = sorted(param_names)
         return param_names
 

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -205,8 +205,6 @@ class BaseObject(_FlagManager):
                 )
         return parameters
 
-    # todo 0.10.0: changed sort default to False
-    # update docstring, and remove warning
     @classmethod
     def get_param_names(cls, sort=None):
         """Get object's parameter names.

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -706,16 +706,21 @@ def test_get_init_signature_raises_error_for_invalid_signature(
         fixture_invalid_init._get_init_signature()
 
 
+@pytest.mark.parametrize("sorted", [True, False])
 def test_get_param_names(
     fixture_object: Type[BaseObject],
     fixture_class_parent: Type[Parent],
     fixture_class_parent_expected_params: Dict[str, Any],
+    sorted: bool,
 ):
     """Test that get_param_names returns list of string parameter names."""
-    param_names = fixture_class_parent.get_param_names()
-    assert param_names == sorted([*fixture_class_parent_expected_params])
+    param_names = fixture_class_parent.get_param_names(sort=sorted)
+    if sorted:
+        assert param_names == sorted([*fixture_class_parent_expected_params])
+    else:
+        assert param_names == [*fixture_class_parent_expected_params]
 
-    param_names = fixture_object.get_param_names()
+    param_names = fixture_object.get_param_names(sort=sorted)
     assert param_names == []
 
 

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -715,7 +715,7 @@ def test_get_param_names(
 ):
     """Test that get_param_names returns list of string parameter names."""
     param_names = fixture_class_parent.get_param_names(sort=sort)
-    if sorted:
+    if sort:
         assert param_names == sorted([*fixture_class_parent_expected_params])
     else:
         assert param_names == [*fixture_class_parent_expected_params]

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -706,21 +706,21 @@ def test_get_init_signature_raises_error_for_invalid_signature(
         fixture_invalid_init._get_init_signature()
 
 
-@pytest.mark.parametrize("sorted", [True, False])
+@pytest.mark.parametrize("sort", [True, False])
 def test_get_param_names(
     fixture_object: Type[BaseObject],
     fixture_class_parent: Type[Parent],
     fixture_class_parent_expected_params: Dict[str, Any],
-    sorted: bool,
+    sort: bool,
 ):
     """Test that get_param_names returns list of string parameter names."""
-    param_names = fixture_class_parent.get_param_names(sort=sorted)
+    param_names = fixture_class_parent.get_param_names(sort=sort)
     if sorted:
         assert param_names == sorted([*fixture_class_parent_expected_params])
     else:
         assert param_names == [*fixture_class_parent_expected_params]
 
-    param_names = fixture_object.get_param_names(sort=sorted)
+    param_names = fixture_object.get_param_names(sort=sort)
     assert param_names == []
 
 


### PR DESCRIPTION
Currently, there is no easy method to return a `BaseObjects`'s parameter name in the same order as they appear in the `__init__`, which is useful in various situations. This is because `get_param_names` does retrieve them, but sorts them alphabetically before returning.

The default should be not sorting, as sorting is an easy operation for the user, whereas retreving the parameters manually is hard.

This PR therefore introduces a new bool parameter `sorted` to `get_param_names` which allows the user to specify whether they want the name sorted.