### PR TITLE
& yarnabrina [ENH] prevent imports in `_check_soft_dependencies`

### DIFF
--- a/skbase/tests/conftest.py
+++ b/skbase/tests/conftest.py
@@ -253,6 +253,7 @@ SKBASE_FUNCTIONS_BY_MODULE.update(
             "_check_python_version",
             "_check_estimator_deps",
             "_normalize_requirement",
+            "_raise_at_severity",
         ),
         "skbase.utils.random_state": (
             "check_random_state",

--- a/skbase/tests/conftest.py
+++ b/skbase/tests/conftest.py
@@ -252,7 +252,6 @@ SKBASE_FUNCTIONS_BY_MODULE.update(
             "_check_soft_dependencies",
             "_check_python_version",
             "_check_estimator_deps",
-            "_get_pkg_version",
             "_normalize_requirement",
         ),
         "skbase.utils.random_state": (

--- a/skbase/tests/conftest.py
+++ b/skbase/tests/conftest.py
@@ -252,6 +252,8 @@ SKBASE_FUNCTIONS_BY_MODULE.update(
             "_check_soft_dependencies",
             "_check_python_version",
             "_check_estimator_deps",
+            "_get_pkg_version",
+            "_normalize_requirement",
         ),
         "skbase.utils.random_state": (
             "check_random_state",

--- a/skbase/utils/dependencies/_dependencies.py
+++ b/skbase/utils/dependencies/_dependencies.py
@@ -2,14 +2,14 @@
 """Utility to check soft dependency imports, and raise warnings or errors."""
 import sys
 import warnings
-from importlib import import_module
+from importlib.metadata import PackageNotFoundError, version
+from importlib.util import find_spec
 from inspect import isclass
 from typing import List
 
 from packaging.requirements import InvalidRequirement, Requirement
-from packaging.specifiers import InvalidSpecifier, SpecifierSet
-
-from skbase.utils.stdout_mute import StdoutMute
+from packaging.specifiers import InvalidSpecifier, Specifier, SpecifierSet
+from packaging.version import InvalidVersion, Version
 
 __author__: List[str] = ["fkiraly", "mloning"]
 
@@ -129,32 +129,44 @@ def _check_soft_dependencies(
             package_import_name = package_import_alias[package_name]
         else:
             package_import_name = package_name
-        # attempt import - if not possible, we know we need to raise warning/exception
-        try:
-            with StdoutMute(active=suppress_import_stdout):
-                pkg_ref = import_module(package_import_name)
-        # if package cannot be imported, make the user aware of installation requirement
-        except ModuleNotFoundError as e:
-            if msg is None:
+
+        # optimized branching to check presence of import
+        # and presence of package distribution
+        # first we check import, then we check distribution
+        # because try/except consumes more runtime
+        pkg_spec = find_spec(package_import_name)
+        if pkg_spec is not None:
+            try:
+                pkg_env_version = Version(version(package_name))
+            except (InvalidVersion, PackageNotFoundError):
+                pkg_spec = None
+
+        # if package not present, make the user aware of installation reqs
+        if pkg_spec is None:
+            if obj is None and msg is None:
                 msg = (
-                    f"{e}. "
-                    f"{class_name} requires package {package!r} to be present "
-                    f"in the python environment, but {package!r} was not found. "
-                )
-                if obj is not None:
-                    msg = msg + (
-                        f"{package!r} is a dependency of {class_name} and required "
-                        f"to construct it. "
-                    )
-                msg = msg + (
-                    f"Please run: `pip install {package}` to "
+                    f"'{package}' not found. "
+                    f"'{package}' is a soft dependency and not included in the "
+                    f"base sktime installation. Please run: `pip install {package}` to "
                     f"install the {package} package. "
+                    f"To install all soft dependencies, run: `pip install "
+                    f"sktime[all_extras]`"
+                )
+            elif msg is None:  # obj is not None, msg is None
+                msg = (
+                    f"{class_name} requires package '{package}' to be present "
+                    f"in the python environment, but '{package}' was not found. "
+                    f"'{package}' is a soft dependency and not included in the base "
+                    f"sktime installation. Please run: `pip install {package}` to "
+                    f"install the {package} package. "
+                    f"To install all soft dependencies, run: `pip install "
+                    f"sktime[all_extras]`"
                 )
             # if msg is not None, none of the above is executed,
             # so if msg is passed it overrides the default messages
 
             if severity == "error":
-                raise ModuleNotFoundError(msg) from e
+                raise ModuleNotFoundError(msg)
             elif severity == "warning":
                 warnings.warn(msg, stacklevel=2)
                 return False
@@ -165,12 +177,10 @@ def _check_soft_dependencies(
                     "Error in calling _check_soft_dependencies, severity "
                     'argument must be "error", "warning", or "none",'
                     f"found {severity!r}."
-                ) from e
+                )
 
         # now we check compatibility with the version specifier if non-empty
         if package_version_req != SpecifierSet(""):
-            pkg_env_version = pkg_ref.__version__
-
             msg = (
                 f"{class_name} requires package {package!r} to be present "
                 f"in the python environment, with version {package_version_req}, "
@@ -339,3 +349,37 @@ def _check_estimator_deps(obj, msg=None, severity="error"):
         compatible = compatible and pkg_deps_ok
 
     return compatible
+
+
+def _normalize_requirement(req):
+    """Normalize packaging Requirement by removing build metadata from versions.
+
+    Parameters
+    ----------
+    req : packaging.requirements.Requirement
+        requirement string to normalize, e.g., Requirement("pandas>1.2.3+foobar")
+
+    Returns
+    -------
+    normalized_req : packaging.requirements.Requirement
+        normalized requirement object with build metadata removed from versions,
+        e.g., Requirement("pandas>1.2.3")
+    """
+    # Process each specifier in the requirement
+    normalized_specs = []
+    for spec in req.specifier:
+        # Parse the version and remove the build metadata
+        spec_v = Version(spec.version)
+        version_wo_build_metadata = f"{spec_v.major}.{spec_v.minor}.{spec_v.micro}"
+
+        # Create a new specifier without the build metadata
+        normalized_spec = Specifier(f"{spec.operator}{version_wo_build_metadata}")
+        normalized_specs.append(normalized_spec)
+
+    # Reconstruct the specifier set
+    normalized_specifier_set = SpecifierSet(",".join(str(s) for s in normalized_specs))
+
+    # Create a new Requirement object with the normalized specifiers
+    normalized_req = Requirement(f"{req.name}{normalized_specifier_set}")
+
+    return normalized_req

--- a/skbase/utils/dependencies/_dependencies.py
+++ b/skbase/utils/dependencies/_dependencies.py
@@ -172,16 +172,6 @@ def _check_soft_dependencies(
                     f"Please run: `pip install {package}` to "
                     f"install the {package} package. "
                 )
-            elif msg is None:  # obj is not None, msg is None
-                msg = (
-                    f"{class_name} requires package '{package}' to be present "
-                    f"in the python environment, but '{package}' was not found. "
-                    f"'{package}' is a soft dependency and not included in the base "
-                    f"sktime installation. Please run: `pip install {package}` to "
-                    f"install the {package} package. "
-                    f"To install all soft dependencies, run: `pip install "
-                    f"sktime[all_extras]`"
-                )
             # if msg is not None, none of the above is executed,
             # so if msg is passed it overrides the default messages
 

--- a/skbase/utils/dependencies/_dependencies.py
+++ b/skbase/utils/dependencies/_dependencies.py
@@ -14,13 +14,14 @@ from packaging.version import InvalidVersion, Version
 __author__: List[str] = ["fkiraly", "mloning"]
 
 
+# todo 0.10.0: remove suppress_import_stdout argument
 def _check_soft_dependencies(
     *packages,
     package_import_alias=None,
     severity="error",
     obj=None,
     msg=None,
-    suppress_import_stdout=False,
+    suppress_import_stdout="deprecated",
 ):
     """Check if required soft dependencies are installed and raise error or warning.
 
@@ -54,8 +55,6 @@ def _check_soft_dependencies(
         if str is passed, will be used as name of the class/object or module
     msg : str, or None, default=None
         if str, will override the error message or warning shown with msg
-    suppress_import_stdout : bool, optional. Default=False
-        whether to suppress stdout printout upon import.
 
     Raises
     ------
@@ -66,6 +65,22 @@ def _check_soft_dependencies(
     -------
     boolean - whether all packages are installed, only if no exception is raised
     """
+    # todo 0.10.0: remove this warning
+    if suppress_import_stdout != "deprecated":
+        warnings.warn(
+            "In skbase _check_soft_dependencies, the suppress_import_stdout argument "
+            "is deprecated and no longer has any effect. "
+            "The argument will be removed in version 0.10.0, so users of the "
+            "_check_soft_dependencies utility should not pass this argument anymore. "
+            "The _check_soft_dependencies utility also no longer causes imports, "
+            "hence no stdout "
+            "output is created from imports, for any setting of the "
+            "suppress_import_stdout argument. If you wish to import packages "
+            "and make use of stdout prints, import the package directly instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     if len(packages) == 1 and isinstance(packages[0], (tuple, list)):
         packages = packages[0]
     if not all(isinstance(x, str) for x in packages):

--- a/skbase/utils/dependencies/_dependencies.py
+++ b/skbase/utils/dependencies/_dependencies.py
@@ -127,6 +127,7 @@ def _check_soft_dependencies(
     for package in packages:
         try:
             req = Requirement(package)
+            req = _normalize_requirement(req)
         except InvalidRequirement:
             msg_version = (
                 f"wrong format for package requirement string, "

--- a/skbase/utils/dependencies/_dependencies.py
+++ b/skbase/utils/dependencies/_dependencies.py
@@ -160,12 +160,17 @@ def _check_soft_dependencies(
         if pkg_spec is None:
             if obj is None and msg is None:
                 msg = (
-                    f"'{package}' not found. "
-                    f"'{package}' is a soft dependency and not included in the "
-                    f"base sktime installation. Please run: `pip install {package}` to "
+                    f"{class_name} requires package {package!r} to be present "
+                    f"in the python environment, but {package!r} was not found. "
+                )
+                if obj is not None:
+                    msg = msg + (
+                        f"{package!r} is a dependency of {class_name} and required "
+                        f"to construct it. "
+                    )
+                msg = msg + (
+                    f"Please run: `pip install {package}` to "
                     f"install the {package} package. "
-                    f"To install all soft dependencies, run: `pip install "
-                    f"sktime[all_extras]`"
                 )
             elif msg is None:  # obj is not None, msg is None
                 msg = (


### PR DESCRIPTION
The `_check_soft_dependencies` utility had inefficiencies and side effects, because to check the soft dependency being present, an import would be attempted, which can lead to circular imports or casacding imports.

This PR replaces the logic with an import-free check.

It also deprecates the argument `suppress_import_stdout`, as there is no longer any import, hence no `stdout` output that would be created.

Mirror of https://github.com/sktime/sktime/pull/6355 which includes contributions by @yarnabrina, and of https://github.com/sktime/sktime/pull/6719