### PR TITLE
[MNT] Move release CI to macos-12 image

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macOS-11]
+        os: [ubuntu-20.04, macOS-12]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:

--- a/docs/source/user_documentation/changelog.rst
+++ b/docs/source/user_documentation/changelog.rst
@@ -31,6 +31,14 @@ Contents
   from ``<0.17.0`` to ``<0.18.0`` (:pr:`343`) :user:`dependabot`
 * [MNT] [Dependabot](deps): Update ``sphinx`` requirement
   from ``!=7.2.0,<8.0.0`` to ``!=7.2.0,<9.0.0`` (:pr:`344`) :user:`dependabot`
+* [MNT] Move release CI to macos-12 image (:pr:`347`) :user:`szepeviktor`
+
+Contributors
+------------
+
+:user:`fkiraly`,
+:user:`szepeviktor`,
+:user:`yarnabrina`
 
 
 [0.8.1] - 2024-06-20


### PR DESCRIPTION
v11 is not available any more
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#standard-github-hosted-runners-for-public-repositories

@fkiraly those jobs do not start
https://github.com/sktime/skbase/actions/runs/10212328626