### PR TITLE
[MNT] release workflow: Upgrade deprecated pypa action parameter

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -146,4 +146,4 @@ jobs:
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages_dir: wheelhouse/
+          packages-dir: wheelhouse/


### PR DESCRIPTION
See the warning in runs
https://github.com/sktime/skbase/actions/runs/10213897671/job/28260425947#step:4:1

Docs: https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#customizing-target-package-dists-directory