### PR TITLE
&toandaominh1997 [BUG] fix dependency checkers in case of multiple distributions available in environment, e.g., on databricks

### DIFF
--- a/skbase/utils/dependencies/_dependencies.py
+++ b/skbase/utils/dependencies/_dependencies.py
@@ -3,7 +3,6 @@
 import sys
 import warnings
 from functools import lru_cache
-from importlib.metadata import distributions
 from inspect import isclass
 
 from packaging.markers import InvalidMarker, Marker
@@ -186,18 +185,19 @@ def _get_installed_packages_private():
     Same as _get_installed_packages, but internal to avoid mutating the lru_cache
     by accident.
     """
+    from importlib.metadata import distributions, version
+
     dists = distributions()
-    # we reverse the list to deal with the case where multiple distributions
-    # of the same package are installed, for instance in deployment setups
-    # with a base environment that has a certain version, that is overridden
-    # by a more recent version in a virtual environment, e.g., on databricks
-    #
-    # in this case, the *first* occurrence of the package in the list is the one
-    # that gets imported, not the last. Thus, for correct version checking,
-    # we need to reverse the list.
-    dists = reversed(list(dists))  # cast to list because chain is not reversible
-    packages = {dist.metadata["Name"]: dist.version for dist in dists}
-    return packages
+    package_names = {dist.metadata["Name"] for dist in dists}
+    package_versions = {pkg_name: version(pkg_name) for pkg_name in package_names}
+    # developer note:
+    # we cannot just use distributions naively,
+    # because the same top level package name may appear *twice*,
+    # e.g., in a situation where a virtual env overrides a base env,
+    # such as in deployment environments like databricks.
+    # the "version" contract ensures we always get the version that corresponds
+    # to the importable distribution, i.e., the top one in the sys.path.
+    return package_versions
 
 
 def _get_installed_packages():

--- a/skbase/utils/dependencies/_dependencies.py
+++ b/skbase/utils/dependencies/_dependencies.py
@@ -187,6 +187,15 @@ def _get_installed_packages_private():
     by accident.
     """
     dists = distributions()
+    # we reverse the list to deal with the case where multiple distributions
+    # of the same package are installed, for instance in deployment setups
+    # with a base environment that has a certain version, that is overridden
+    # by a more recent version in a virtual environment, e.g., on databricks
+    #
+    # in this case, the *first* occurrence of the package in the list is the one
+    # that gets imported, not the last. Thus, for correct version checking,
+    # we need to reverse the list.
+    dists = reversed(list(dists))  # cast to list because chain is not reversible
     packages = {dist.metadata["Name"]: dist.version for dist in dists}
     return packages
 


### PR DESCRIPTION
Mirror bugfix of https://github.com/sktime/sktime/pull/6986 in preparation of deduplication refactor.