### PR TITLE
[ENH] safer `get_fitted_params` default functionality to avoid exception on `getattr`

### DIFF
--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -1294,10 +1294,35 @@ class BaseEstimator(BaseObject):
         ]
 
         def getattr_safe(obj, attr):
+            """Get attribute of object, safely.
+
+            Safe version of getattr, that returns None if attribute does not exist,
+            or if an exception is raised during getattr.
+            Also returns a boolean indicating whether the attribute was successfully
+            retrieved, to distinguish between None value and non-existent attribute,
+            or exception during getattr.
+
+            Parameters
+            ----------
+            obj : any object
+                object to get attribute from
+            attr : str
+                attribute name to get from obj
+
+            Returns
+            -------
+            attr : Any
+                attribute of obj, if it exists and does not raise on getattr;
+                otherwise None
+            success : bool
+                whether the attribute was successfully retrieved
+            """
             try:
                 if hasattr(obj, attr):
                     attr = getattr(obj, attr)
                     return attr, True
+                else:
+                    return None, False
             except Exception:
                 return None, False
 
@@ -1305,10 +1330,9 @@ class BaseEstimator(BaseObject):
 
         for p in fitted_params:
             attr, success = getattr_safe(obj, p)
-            if not success:
-                continue
-            p_name = p[:-1]  # remove the "_" at the end to get the parameter name
-            fitted_param_dict[p_name] = attr
+            if success:
+                p_name = p[:-1]  # remove the "_" at the end to get the parameter name
+                fitted_param_dict[p_name] = attr
 
         return fitted_param_dict
 

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -1292,9 +1292,18 @@ class BaseEstimator(BaseObject):
         fitted_params = [
             attr for attr in dir(obj) if attr.endswith("_") and not attr.startswith("_")
         ]
+
+        def hasattr_safe(obj, attr):
+            try:
+                if hasattr(obj, attr):
+                    getattr(obj, attr)
+                    return True
+            except Exception:
+                return False
+
         # remove the "_" at the end
         fitted_param_dict = {
-            p[:-1]: getattr(obj, p) for p in fitted_params if hasattr(obj, p)
+            p[:-1]: getattr(obj, p) for p in fitted_params if hasattr_safe(obj, p)
         }
 
         return fitted_param_dict

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -1293,18 +1293,22 @@ class BaseEstimator(BaseObject):
             attr for attr in dir(obj) if attr.endswith("_") and not attr.startswith("_")
         ]
 
-        def hasattr_safe(obj, attr):
+        def getattr_safe(obj, attr):
             try:
                 if hasattr(obj, attr):
-                    getattr(obj, attr)
-                    return True
+                    attr = getattr(obj, attr)
+                    return attr, True
             except Exception:
-                return False
+                return None, False
 
-        # remove the "_" at the end
-        fitted_param_dict = {
-            p[:-1]: getattr(obj, p) for p in fitted_params if hasattr_safe(obj, p)
-        }
+        fitted_param_dict = {}
+
+        for p in fitted_params:
+            attr, success = getattr_safe(obj, p)
+            if not success:
+                continue
+            p_name = p[:-1]  # remove the "_" at the end to get the parameter name
+            fitted_param_dict[p_name] = attr
 
         return fitted_param_dict
 


### PR DESCRIPTION
This PR makes the `get_fitted_params` core functionality and defaults safer against exceptions on `getattr`.

In rare cases, `getattr` can cause an exception, namely if a property is being accessed in a way that generates an exception.

Examples are some fitted parameter arguments in `sklearn` that are decorated as property in newer versions, e.g., `RandomForestRegressor.estimator_` in unfitted state.

In most use cases, there will be no change in behaviour; in the described case where an exception would be raised, this is now caught and suppressed, and the corresponding parameter is considered as not present.

Changes occur only in cases that would have previously raised genuine exceptions, so no working code is affected, and no deprecation is necessary despite this being a change to a core interface element.