### PR TITLE
[MNT] python 3.13 wheels and 3.13-rc.2 testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest, macOS-latest, windows-latest]
-          python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13-rc.2"]
+          python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-rc.2"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest, macOS-latest, windows-latest]
-          python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+          python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13-rc.2"]
     steps:
       - uses: actions/checkout@v4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.8,<3.14"
 dependencies = []
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ test = [
     "numpy",
     "scipy",
     "pandas",
-    "scikit-learn>=0.24.0",
+    'scikit-learn>=0.24.0; python_version < "3.13" or sys_platform != "win32"',
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.8,<3.13"
 dependencies = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = []
 all_extras = ["numpy", "pandas"]
 
 dev = [
-    'scikit-learn>=0.24.0; python_version < "3.13" or sys_platform != "win32"',
+    'scikit-learn>=0.24.0; not (python_version >= "3.13" and python_version < "3.14" and sys_platform == "win32")',
     "pre-commit",
     "pytest",
     "pytest-cov"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = []
 all_extras = ["numpy", "pandas"]
 
 dev = [
-    "scikit-learn>=0.24.0",
+    "scikit-learn>=0.24.0; not (python_version == '3.13' and sys_platform == 'win32')",
     "pre-commit",
     "pytest",
     "pytest-cov"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = []
 all_extras = ["numpy", "pandas"]
 
 dev = [
-    "scikit-learn>=0.24.0; not (python_version == '3.13' and sys_platform == 'win32')",
+    'scikit-learn>=0.24.0; not (python_version == "3.13" and sys_platform == "win32")',
     "pre-commit",
     "pytest",
     "pytest-cov"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = []
 all_extras = ["numpy", "pandas"]
 
 dev = [
-    'scikit-learn>=0.24.0; not (python_version == "3.13" and sys_platform == "win32")',
+    'scikit-learn>=0.24.0; python_version != "3.13" or sys_platform != "win32"',
     "pre-commit",
     "pytest",
     "pytest-cov"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = []
 all_extras = ["numpy", "pandas"]
 
 dev = [
-    'scikit-learn>=0.24.0; python_version < "3.13" or sys_platform != "win32"',
+    'scikit-learn>=0.24.0; python_version < "3.13" or sys_platform != "win32"',  # todo 0.11.0 - check if windows 3.13 works, if yes, remove markers
     "pre-commit",
     "pytest",
     "pytest-cov"
@@ -87,7 +87,7 @@ test = [
     "numpy",
     "scipy",
     "pandas",
-    'scikit-learn>=0.24.0; python_version < "3.13" or sys_platform != "win32"',
+    'scikit-learn>=0.24.0; python_version < "3.13" or sys_platform != "win32"',  # todo 0.11.0 - check if windows 3.13 works, if yes, remove markers
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = []
 all_extras = ["numpy", "pandas"]
 
 dev = [
-    'scikit-learn>=0.24.0; python_version != "3.13" or sys_platform != "win32"',
+    'scikit-learn>=0.24.0; python_version < "3.13" or sys_platform != "win32"',
     "pre-commit",
     "pytest",
     "pytest-cov"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = []
 all_extras = ["numpy", "pandas"]
 
 dev = [
-    'scikit-learn>=0.24.0; not (python_version >= "3.13" and python_version < "3.14" and sys_platform == "win32")',
+    'scikit-learn>=0.24.0; python_version < "3.13" or sys_platform != "win32"',
     "pre-commit",
     "pytest",
     "pytest-cov"


### PR DESCRIPTION
Adds experimental 3.13 wheels and testing on 3.13-rc.2, ahead of the 3.13 release early Oct 2024.

Full 3.13 support should be released with 0.11.0 only.

Towards https://github.com/sktime/skbase/issues/367