### PR TITLE
[MNT] updates `sklearn` soft dependency checks to use PEP 440 name

### DIFF
--- a/skbase/base/_pretty_printing/tests/test_pprint.py
+++ b/skbase/base/_pretty_printing/tests/test_pprint.py
@@ -2,7 +2,10 @@
 # copyright: skbase developers, BSD-3-Clause License (see LICENSE file)
 """Tests for skbase pretty printing functionality."""
 
+import pytest
+
 from skbase.base import BaseObject
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 class CompositionDummy(BaseObject):
@@ -15,6 +18,10 @@ class CompositionDummy(BaseObject):
         super(CompositionDummy, self).__init__()
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("scikit-learn", severity="none"),
+    reason="skip test if sklearn is not available",
+)  # sklearn is part of the dev dependency set, test should be executed with that
 def test_sklearn_compatibility():
     """Test that the pretty printing functions are compatible with sklearn."""
     from sklearn.ensemble import RandomForestRegressor

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -1022,7 +1022,7 @@ def test_nested_config_after_clone_tags(clone_config):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("sklearn", severity="none"),
+    not _check_soft_dependencies("scikit-learn", severity="none"),
     reason="skip test if sklearn is not available",
 )  # sklearn is part of the dev dependency set, test should be executed with that
 def test_clone_param_is_none(fixture_class_parent: Type[Parent]):
@@ -1037,7 +1037,7 @@ def test_clone_param_is_none(fixture_class_parent: Type[Parent]):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("sklearn", severity="none"),
+    not _check_soft_dependencies("scikit-learn", severity="none"),
     reason="skip test if sklearn is not available",
 )  # sklearn is part of the dev dependency set, test should be executed with that
 def test_clone_empty_array(fixture_class_parent: Type[Parent]):
@@ -1057,7 +1057,7 @@ def test_clone_empty_array(fixture_class_parent: Type[Parent]):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("sklearn", severity="none"),
+    not _check_soft_dependencies("scikit-learn", severity="none"),
     reason="skip test if sklearn is not available",
 )  # sklearn is part of the dev dependency set, test should be executed with that
 def test_clone_sparse_matrix(fixture_class_parent: Type[Parent]):
@@ -1076,7 +1076,7 @@ def test_clone_sparse_matrix(fixture_class_parent: Type[Parent]):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("sklearn", severity="none"),
+    not _check_soft_dependencies("scikit-learn", severity="none"),
     reason="skip test if sklearn is not available",
 )  # sklearn is part of the dev dependency set, test should be executed with that
 def test_clone_nan(fixture_class_parent: Type[Parent]):
@@ -1105,7 +1105,7 @@ def test_clone_estimator_types(fixture_class_parent: Type[Parent]):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("sklearn", severity="none"),
+    not _check_soft_dependencies("scikit-learn", severity="none"),
     reason="skip test if sklearn is not available",
 )  # sklearn is part of the dev dependency set, test should be executed with that
 def test_clone_class_rather_than_instance_raises_error(
@@ -1120,7 +1120,7 @@ def test_clone_class_rather_than_instance_raises_error(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("sklearn", severity="none"),
+    not _check_soft_dependencies("scikit-learn", severity="none"),
     reason="skip test if sklearn is not available",
 )  # sklearn is part of the dev dependency set, test should be executed with that
 def test_clone_sklearn_composite(fixture_class_parent: Type[Parent]):

--- a/skbase/utils/tests/test_deep_equals.py
+++ b/skbase/utils/tests/test_deep_equals.py
@@ -71,9 +71,7 @@ if _check_soft_dependencies("pandas", severity="none"):
 
     EXAMPLES += [X]
 
-if _check_soft_dependencies(
-    "scikit-learn", package_import_alias={"scikit-learn": "sklearn"}, severity="none"
-):
+if _check_soft_dependencies("scikit-learn", severity="none"):
     from sklearn.ensemble import RandomForestRegressor
 
     EXAMPLES += [RandomForestRegressor()]
@@ -115,16 +113,12 @@ def test_deep_equals_negative(fixture1, fixture2):
 def copy_except_if_sklearn(obj):
     """Copy obj if it is not a scikit-learn estimator.
 
-    We use this functoin as deep_copy should return True for
+    We use this function as deep_copy should return True for
     identical sklearn estimators, but False for different copies.
 
     This is the current status quo, possibly we want to change this in the future.
     """
-    if not _check_soft_dependencies(
-        "scikit-learn",
-        package_import_alias={"scikit-learn": "sklearn"},
-        severity="none",
-    ):
+    if not _check_soft_dependencies("scikit-learn", severity="none"):
         return deepcopy(obj)
     else:
         from sklearn.base import BaseEstimator


### PR DESCRIPTION
This PR updates the `sklearn` soft dependency checks via `_check_soft_dependencies`to use the PEP 440 name, `scikit-learn`.