### PR TITLE
[DOC] merge docstring of `NotFittedError` with `sktime`

### DIFF
--- a/skbase/_exceptions.py
+++ b/skbase/_exceptions.py
@@ -21,11 +21,10 @@ class FixtureGenerationError(Exception):
 class NotFittedError(ValueError, AttributeError):
     """Exception class to raise if estimator is used before fitting.
 
-    This class inherits from both ValueError and AttributeError to help with
+    This class inherits from both ``ValueError`` and ``AttributeError`` to help with
     exception handling.
 
     References
     ----------
-    [1] scikit-learn's NotFittedError
-    [2] sktime's NotFittedError
+    .. [1] Based on scikit-learn's NotFittedError
     """


### PR DESCRIPTION
Merges docstring of `NotFittedError` with `sktime` docstring, in preparation of refactor unification.