### PR TITLE
[MNT] manage python 3.8 end-of-life

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest, macOS-latest, windows-latest]
-          python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+          python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macOS-12]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -66,11 +66,6 @@ jobs:
         include:
           # Window 64 bit
           - os: windows-2019
-            python: 38
-            python-version: '3.8'
-            bitness: 64
-            platform_id: win_amd64
-          - os: windows-2019
             python: 39
             python-version: '3.9'
             bitness: 64
@@ -88,6 +83,11 @@ jobs:
           - os: windows-2019
             python: 312
             python-version: 3.12
+            bitness: 64
+            platform_id: win_amd64
+          - os: windows-2019
+            python: 313
+            python-version: 3.13
             bitness: 64
             platform_id: win_amd64
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For trouble shooting or more information, see our
 [detailed installation instructions](https://skbase.readthedocs.io/en/latest/user_documentation/installation.html).
 
 - **Operating system**: macOS X · Linux · Windows 8.1 or higher
-- **Python version**: Python 3.8, 3.9, 3.10, 3.11 and 3.12
+- **Python version**: Python 3.9, 3.10, 3.11, 3.12, and 3.13
 - **Package managers**: [pip]
 
 [pip]: https://pip.pypa.io/en/stable/

--- a/docs/source/get_started.rst
+++ b/docs/source/get_started.rst
@@ -13,7 +13,7 @@ Installation
 
 ``skbase`` currently supports:
 
-* environments with python version 3.8, 3.9, 3.10, 3.11 or 3.12
+* environments with python version 3.9, 3.10, 3.11, 3.12, or 3.13
 * operating systems Mac OS X, Unix-like OS, Windows 8.1 and higher
 * installation via ``PyPi``
 

--- a/docs/source/user_documentation/installation.rst
+++ b/docs/source/user_documentation/installation.rst
@@ -6,7 +6,7 @@ Installation
 
 ``skbase`` currently supports:
 
-* environments with python version 3.8, 3.9, 3.10, 3.11 or 3.12
+* environments with python version 3.9, 3.10, 3.11, 3.12, or 3.13
 * operating systems Mac OS X, Unix-like OS, Windows 8.1 and higher
 
 Checkout the full list of pre-compiled wheels on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,14 +26,13 @@ classifiers = [
     "Operating System :: POSIX",
     "Operating System :: Unix",
     "Operating System :: MacOS",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.8,<3.14"
+requires-python = ">=3.9,<3.14"
 dependencies = []
 
 [project.optional-dependencies]


### PR DESCRIPTION
Python 3.8 has reached end-of-life, that is addressed in this PR:

* removal of python 3.8 from package support tags
* removal of python 3.8 from CI
* removal of python 3.8 support references from documentation

In some of the above places, python 3.13 was not present, in those cases python 3.13 was also added.