### PR TITLE
[ENH] customizable special attrs in clone

### DIFF
--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -1715,8 +1715,8 @@ def _clone(estimator, *, safe=True, clone_attrs=None):
     klass = estimator.__class__
     new_object_params = estimator.get_params(deep=False)
     for name, param in new_object_params.items():
-        if isinstance(estimator, BaseObject) and hasattr(estimator, "clone"):
-            new_object_params[name] = estimator.clone()
+        if isinstance(param, BaseObject) and hasattr(param, "clone"):
+            new_object_params[name] = param.clone()
         else:
             new_object_params[name] = _clone(param, safe=False)
     new_object = klass(**new_object_params)

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -1715,7 +1715,10 @@ def _clone(estimator, *, safe=True, clone_attrs=None):
     klass = estimator.__class__
     new_object_params = estimator.get_params(deep=False)
     for name, param in new_object_params.items():
-        new_object_params[name] = _clone(param, safe=False)
+        if isinstance(estimator, BaseObject) and hasattr(estimator, "clone"):
+            new_object_params[name] = estimator.clone()
+        else:
+            new_object_params[name] = _clone(param, safe=False)
     new_object = klass(**new_object_params)
     params_set = new_object.get_params(deep=False)
 


### PR DESCRIPTION
This PR adds a `clone_attrs` config field which lets users specify a list of strings, attribute names which are retained in `clone` beyond the configs and init parameters.

This is by default `None`, so retains current behaviour.

An approach to https://github.com/sktime/sktime/issues/7333, which would be solved if we set the `sklearn` specific attribute responsible for `set_output` in this list, in `sktime` only.

The main drawback of this would be that `sklearn` compatibility is not automatic, but contingent on setting this hard-to-find config.