### PR TITLE
[BUG] Accepting prereleases as valid python version

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -103,6 +103,15 @@
         "contributions": [
           "maintenance"
         ]
+      },
+      {
+        "login": "Abelarm",
+        "name": "Luigi Giugliano",
+        "avatar_url": "https://avatars.githubusercontent.com/u/6976921?v=4",
+        "profile": "https://github.com/Abelarm",
+        "contributions": [
+          "code"
+        ]
       }
   ],
   "projectName": "skbase",

--- a/skbase/utils/dependencies/_dependencies.py
+++ b/skbase/utils/dependencies/_dependencies.py
@@ -262,7 +262,10 @@ def _check_python_version(
           function returns False if one of packages is not installed, otherwise True
 
     prereleases: str, default = True
-        if include prereleases while checking, if False will not include prereleases
+        If True, allows prerelease versions to be considered compatible.
+        If False, always considers prerelease versions as incompatible, i.e., always
+        raises error, warning, or returns False, if the system python version is a
+        prerelease.
 
     Returns
     -------

--- a/skbase/utils/dependencies/_dependencies.py
+++ b/skbase/utils/dependencies/_dependencies.py
@@ -262,6 +262,7 @@ def _check_python_version(
           function returns False if one of packages is not installed, otherwise True
 
     prereleases: str, default = True
+        Whether prerelease versions are considered compatible.
         If True, allows prerelease versions to be considered compatible.
         If False, always considers prerelease versions as incompatible, i.e., always
         raises error, warning, or returns False, if the system python version is a

--- a/skbase/utils/dependencies/_dependencies.py
+++ b/skbase/utils/dependencies/_dependencies.py
@@ -236,7 +236,9 @@ def _get_pkg_version(package_name):
     return pkg_env_version
 
 
-def _check_python_version(obj, package=None, msg=None, severity="error"):
+def _check_python_version(
+    obj, package=None, msg=None, severity="error", prereleases=True
+):
     """Check if system python version is compatible with requirements of obj.
 
     Parameters
@@ -259,6 +261,9 @@ def _check_python_version(obj, package=None, msg=None, severity="error"):
         * "none" - does not raise exception or warning
           function returns False if one of packages is not installed, otherwise True
 
+    prereleases: str, default = True
+        if include prereleases while checking, if False will not include prereleases
+
     Returns
     -------
     compatible : bool, whether obj is compatible with system python version
@@ -276,7 +281,7 @@ def _check_python_version(obj, package=None, msg=None, severity="error"):
         return True
 
     try:
-        est_specifier = SpecifierSet(est_specifier_tag)
+        est_specifier = SpecifierSet(est_specifier_tag, prereleases=prereleases)
     except InvalidSpecifier:
         msg_version = (
             f"wrong format for python_version tag, "

--- a/skbase/utils/dependencies/_dependencies.py
+++ b/skbase/utils/dependencies/_dependencies.py
@@ -312,6 +312,9 @@ def _check_python_version(
             f" but system python version is {sys.version}."
         )
 
+        if "rc" in sys_version:
+            msg += " This is due to the release candidate status of your system Python."
+
         if package is not None:
             msg += (
                 f" This is due to python version requirements of the {package} package."

--- a/skbase/utils/dependencies/tests/test_check_dependencies.py
+++ b/skbase/utils/dependencies/tests/test_check_dependencies.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """Tests for _check_soft_dependencies utility."""
-import pytest
 from unittest.mock import patch
+
+import pytest
 from packaging.requirements import InvalidRequirement
 
-from skbase.utils.dependencies import _check_soft_dependencies, _check_python_version
+from skbase.utils.dependencies import _check_python_version, _check_soft_dependencies
 
 
 def test_check_soft_deps():
@@ -48,6 +49,7 @@ def test_check_soft_deps():
         assert _check_soft_dependencies(
             ("pytest", "!!numpy<~><>0.1.0"), severity="none"
         )
+
 
 @patch("sktime.utils.dependencies._dependencies.sys")
 @pytest.mark.parametrize(
@@ -97,4 +99,3 @@ def test_check_python_version(
                 f"\n\t - prereleases: {prereleases},",
                 f"\nERROR MESSAGE: {exception.msg}",
             )
-

--- a/skbase/utils/dependencies/tests/test_check_dependencies.py
+++ b/skbase/utils/dependencies/tests/test_check_dependencies.py
@@ -51,7 +51,7 @@ def test_check_soft_deps():
         )
 
 
-@patch("sktime.utils.dependencies._dependencies.sys")
+@patch("skbase.utils.dependencies._dependencies.sys")
 @pytest.mark.parametrize(
     "mock_release_version, prereleases, expect_exception",
     [

--- a/skbase/utils/dependencies/tests/test_check_dependencies.py
+++ b/skbase/utils/dependencies/tests/test_check_dependencies.py
@@ -91,7 +91,7 @@ def test_check_python_version(
             "This is due to the release candidate status of your system Python."
         )
 
-        if not expect_exception or not exception.msg == expected_msg:
+        if not expect_exception or exception.msg != expected_msg:
             # Throw Error since exception is not expected or has not the correct message
             raise AssertionError(
                 "ModuleNotFoundError should be NOT raised by:",

--- a/skbase/utils/dependencies/tests/test_check_dependencies.py
+++ b/skbase/utils/dependencies/tests/test_check_dependencies.py
@@ -98,4 +98,4 @@ def test_check_python_version(
                 f"\n\t - mock_release_version: {mock_release_version},",
                 f"\n\t - prereleases: {prereleases},",
                 f"\nERROR MESSAGE: {exception.msg}",
-            )
+            ) from exception

--- a/skbase/utils/dependencies/tests/test_check_dependencies.py
+++ b/skbase/utils/dependencies/tests/test_check_dependencies.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 """Tests for _check_soft_dependencies utility."""
 import pytest
+from unittest.mock import patch
 from packaging.requirements import InvalidRequirement
 
-from skbase.utils.dependencies._dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies, _check_python_version
 
 
 def test_check_soft_deps():
@@ -47,3 +48,53 @@ def test_check_soft_deps():
         assert _check_soft_dependencies(
             ("pytest", "!!numpy<~><>0.1.0"), severity="none"
         )
+
+@patch("sktime.utils.dependencies._dependencies.sys")
+@pytest.mark.parametrize(
+    "mock_release_version, prereleases, expect_exception",
+    [
+        (True, True, False),
+        (True, False, True),
+        (False, False, False),
+        (False, True, False),
+    ],
+)
+def test_check_python_version(
+    mock_sys, mock_release_version, prereleases, expect_exception
+):
+    from skbase.base import BaseObject
+
+    if mock_release_version:
+        mock_sys.version = "3.8.1rc"
+    else:
+        mock_sys.version = "3.8.1"
+
+    class DummyObjectClass(BaseObject):
+        _tags = {
+            "python_version": ">=3.7.1",  # PEP 440 version specifier, e.g., ">=3.7"
+            "python_dependencies": None,  # PEP 440 dependency strs, e.g., "pandas>=1.0"
+            "env_marker": None,  # PEP 508 environment marker, e.g., "os_name=='posix'"
+        }
+        """Define dummy class to test set_tags."""
+
+    dummy_object_instance = DummyObjectClass()
+
+    try:
+        _check_python_version(dummy_object_instance, prereleases=prereleases)
+    except ModuleNotFoundError as exception:
+        expected_msg = (
+            f"{type(dummy_object_instance).__name__} requires python version "
+            f"to be {dummy_object_instance.get_tags()['python_version']}, "
+            f"but system python version is {mock_sys.version}. "
+            "This is due to the release candidate status of your system Python."
+        )
+
+        if not expect_exception or not exception.msg == expected_msg:
+            # Throw Error since exception is not expected or has not the correct message
+            assert False, (
+                "ModuleNotFoundError should be NOT raised by:",
+                f"\n\t - mock_release_version: {mock_release_version},",
+                f"\n\t - prereleases: {prereleases},",
+                f"\nERROR MESSAGE: {exception.msg}",
+            )
+

--- a/skbase/utils/dependencies/tests/test_check_dependencies.py
+++ b/skbase/utils/dependencies/tests/test_check_dependencies.py
@@ -93,7 +93,7 @@ def test_check_python_version(
 
         if not expect_exception or not exception.msg == expected_msg:
             # Throw Error since exception is not expected or has not the correct message
-            assert False, (
+            raise AssertionError(
                 "ModuleNotFoundError should be NOT raised by:",
                 f"\n\t - mock_release_version: {mock_release_version},",
                 f"\n\t - prereleases: {prereleases},",


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes: https://github.com/sktime/sktime/issues/7517


Make "rc" python version recognizable during python version checking.
Introducing a parameter `prereleases=True`
The following code snipped now returns true:
```python
"3.11.0rc1" in SpecifierSet(">3.8", prereleases=True) 
```

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?
On the tests regarding checking python versions.

#### PR checklist

##### For all contributions
- [x] I've reviewed the project documentation on [contributing](https://skbase.readthedocs.io/en/latest/contribute.html)
- [x] I've added myself to the [list of contributors](https://github.com/sktime/skbase/blob/main/.all-contributorsrc).
- [x] The PR title starts with either [ENH], [CI/CD], [MNT], [DOC], or [BUG] indicating whether
  the PR topic is related to enhancement, CI/CD, maintenance, documentation, or a bug.

##### For code contributions
- [ ] Unit tests have been added covering code functionality
- [x] Appropriate docstrings have been added (see [documentation standards](https://skbase.readthedocs.io/en/latest/contribute/development/developer_guide/creating_docs.html))
