### PR TITLE
[MNT] remove macos pre-release tests in release workflow

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macOS-12]
+        os: [ubuntu-20.04]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:


### PR DESCRIPTION
This PR removes macos pre-release tests in the release workflow, because there is a far lower concurrency limit on macos tests, and unix is tested already via ubuntu.

Macos is also still tested in the main CI triggered by pull requests.