### PR TITLE
[MNT] use `macos-latest` and `ubuntu-latest` in release workflow

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macOS-12]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:


### PR DESCRIPTION
Changes the release workflow to use `macos-latest` and `ubuntu-latest` for pre-release testing.