### PR TITLE
[MNT] update `nodevdeps` runner to latest `ubuntu`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
 
   test-nodevdeps:
     needs: code-quality
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Updates the `nodevdeps` runner to `ubuntu-latest`, from a fixed version that is no longer supported.