### PR TITLE
[BUG] fix `_check_soft_dependencies` error message if version is wrong

### DIFF
--- a/skbase/utils/dependencies/_dependencies.py
+++ b/skbase/utils/dependencies/_dependencies.py
@@ -158,6 +158,8 @@ def _check_soft_dependencies(
         -------
         package_version_req: SpecifierSet
             version requirement object from package string
+        package_name: str
+            name of package, PEP 440 compatible specifier string, e.g., "scikit-learn"
         pkg_env_version: Version
             version object of package in python environment
         """
@@ -177,11 +179,11 @@ def _check_soft_dependencies(
         package_name = req.name
         package_version_req = req.specifier
 
-        pkg_env_version = _get_pkg_version(package_name, case_sensitive=case_sensitive)
+        pkg_env_version = _get_pkg_version(package_name)
         if normalize_reqs:
             pkg_env_version = _normalize_version(pkg_env_version)
 
-        return package_version_req, pkg_env_version
+        return package_version_req, package_name, pkg_env_version
 
     # each element of the list "package" must be satisfied
     for package_req in packages:
@@ -205,13 +207,15 @@ def _check_soft_dependencies(
 
         pkg_version_reqs = []
         pkg_env_versions = []
+        pkg_names = []
         nontrivital_bound = []
         req_sat = []
 
         for package in package_req:
-            pkg_version_req, pkg_env_version = _get_pkg_version_and_req(package)
+            pkg_version_req, pkg_nm, pkg_env_version = _get_pkg_version_and_req(package)
             pkg_version_reqs.append(pkg_version_req)
             pkg_env_versions.append(pkg_env_version)
+            pkg_names.append(pkg_nm)
             nontrivital_bound.append(pkg_version_req != SpecifierSet(""))
             req_sat.append(_is_version_req_satisfied(pkg_env_version, pkg_version_req))
 
@@ -250,10 +254,9 @@ def _check_soft_dependencies(
 
         # now we check compatibility with the version specifier if non-empty
         if not any(req_sat):
-            reqs_not_satisfied = [
-                x for x in zip(package_req, pkg_env_versions, req_sat) if x[2] is False
-            ]
-            actual_vers = [f"{x[0]} {x[1]}" for x in reqs_not_satisfied]
+            zp = zip(package_req, pkg_names, pkg_env_versions, req_sat)
+            reqs_not_satisfied = [x for x in zp if x[3] is False]
+            actual_vers = [f"{x[1]} {x[2]}" for x in reqs_not_satisfied]
             pkg_env_version_str = ", ".join(actual_vers)
 
             msg = (


### PR DESCRIPTION
This PR fixes the `_check_soft_dependencies` error message if the right packages are present but the version is wrong.

Mirror of https://github.com/sktime/sktime/pull/8430.