### PR TITLE
[MNT] replace deprecated `windows-2019` runner with `windows-latest` in `wheels` release workflow

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -60,32 +60,32 @@ jobs:
   test_windows_wheels:
     needs: build_wheels
     name: Test wheels on ${{ matrix.os }} with ${{ matrix.python-version }}
-    runs-on: windows-2019
+    runs-on: windows-latest
     strategy:
       matrix:
         include:
           # Window 64 bit
-          - os: windows-2019
+          - os: windows-latest
             python: 39
             python-version: '3.9'
             bitness: 64
             platform_id: win_amd64
-          - os: windows-2019
+          - os: windows-latest
             python: 310
             python-version: '3.10'
             bitness: 64
             platform_id: win_amd64
-          - os: windows-2019
+          - os: windows-latest
             python: 311
             python-version: 3.11
             bitness: 64
             platform_id: win_amd64
-          - os: windows-2019
+          - os: windows-latest
             python: 312
             python-version: 3.12
             bitness: 64
             platform_id: win_amd64
-          - os: windows-2019
+          - os: windows-latest
             python: 313
             python-version: 3.13
             bitness: 64

--- a/docs/source/user_documentation/changelog.rst
+++ b/docs/source/user_documentation/changelog.rst
@@ -28,6 +28,8 @@ Contents
 * [MNT] use ``macos-latest`` and ``ubuntu-latest`` in release workflow
   (:pr:`411`, :pr:`420`) :user:`fkiraly`
 * [MNT] update ``nodevdeps`` runner to latest ``ubuntu`` (:pr:`416`) :user:`fkiraly`
+* [MNT] replace deprecated ``windows-2019`` runner with ``windows-latest`` in ``wheels``
+  release workflow (:pr:`432`) :user:`fkiraly`
 * [BUG] ensure ``all_objects`` handles decorators properly (:pr:`418`) :user:`fkiraly`
 * [BUG] fix ``TagAliaserMixin`` missing warnings (:pr:`414`) :user:`fkiraly`
 


### PR DESCRIPTION
replaces the deprecated `windows-2019` runner with `windows-latest` in `wheels` release workflow