### PR TITLE
[ENH] ensure `_get_installed_packages` does not break in case of incomplete or corrupted package metadata

### DIFF
--- a/skbase/utils/dependencies/_dependencies.py
+++ b/skbase/utils/dependencies/_dependencies.py
@@ -290,6 +290,7 @@ def _get_installed_packages_private(lowercase=False):
     from importlib.metadata import distributions, version
 
     dists = distributions()
+    dists = {dist for dist in dists if dist.metadata is not None}
     package_names = {dist.metadata["Name"] for dist in dists}
     package_versions = {pkg_name: version(pkg_name) for pkg_name in package_names}
     # developer note:


### PR DESCRIPTION
This PR ensures that `_get_installed_packages` does not break in case of incomplete or corrupted package metadata.

Fixes issue as observed in https://github.com/sktime/pytorch-forecasting/issues/1925.