### PR TITLE
[MNT] remove deprecated `fix-encoding-pragma` hook from `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,6 @@ repos:
       - id: check-toml
       - id: debug-statements
       - id: end-of-file-fixer
-      - id: fix-encoding-pragma
       - id: requirements-txt-fixer
       - id: trailing-whitespace
       - id: check-docstring-first


### PR DESCRIPTION
removes the deprecated `fix-encoding-pragma` hook from `pre-commit`