### PR TITLE
[BUG] fix `TagAliaserMixin` `get_tag` and `get_class_tag`

### DIFF
--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -1480,9 +1480,7 @@ class TagAliaserMixin:
                 pkg_name = cls._package_name
                 if pkg_name != "":
                     pkg_name = f"{pkg_name} "
-                msg = (
-                    f"tag {tag_name!r} will be removed in {pkg_name}version {version}"
-                )
+                msg = f"tag {tag_name!r} will be removed in {pkg_name}version {version}"
                 if new_tag != "":
                     msg += (
                         f" and replaced by {new_tag!r}, please use {new_tag!r} instead"


### PR DESCRIPTION
The `TagAliaserMixin`  methods `get_tag` and `get_class_tag` were not behaving as intended: they were not aliasing the tags.

This is fixed by delegating to the correctly behaving `get_tags` and `get_class_tags` in case a tag is aliasing or aliased.