### PR TITLE
[BUG] regression test certifying for fix #115

### DIFF
--- a/skbase/tests/test_lookup.py
+++ b/skbase/tests/test_lookup.py
@@ -1,0 +1,35 @@
+"""Tests for skbase.lookup utilities."""
+
+import importlib
+import sys
+
+from skbase.lookup import all_objects
+
+
+def test_all_objects_returns_class_name_for_alias(tmp_path, monkeypatch):
+    """all_objects should report the underlying class name, not an alias."""
+    pkg_name = "pkg_alias_case"
+    root = tmp_path / pkg_name
+    root.mkdir()
+
+    # create a tmp module to test all_objects behaviour
+    (root / "__init__.py").write_text(
+        "from .module import AliasName\n" "__all__ = ['AliasName']\n"
+    )
+    (root / "module.py").write_text(
+        "from skbase.base import BaseObject\n\n"
+        "class ActualName(BaseObject):\n"
+        "    pass\n\n"
+        "AliasName = ActualName\n"
+        "__all__ = ['AliasName']\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    importlib.invalidate_caches()
+
+    objs = all_objects(package_name=pkg_name, path=str(root))
+    assert len(objs) == 1
+    name, klass = objs[0]
+    assert name == klass.__name__ == "ActualName"
+
+    sys.modules.pop(f"{pkg_name}.module", None)
+    sys.modules.pop(pkg_name, None)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #112 by adding a test


#### What does this implement/fix? Explain your changes.

This does not fix anything, since the bug is apparently already fixed by #115. But it adds a minimal test. 

The test creates a dummy module to test the behaviour of `all_objects`. This dummy module might be useful for testing, because it is independent from the existing code. I verified, that the test fails (in an expected way) before #115 was merged (while all other tests passed). So this test should give some additional safety in the future.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution requires a new dependency please indicate why it is necessary.
skbase seeks to minimize dependencies to make it easy to use skbase in a variety
of environments and contexts.
-->

No

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development.
You can guide the reviews to focus on the parts that are ready for their comments.
We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Any other comments?
<!--
Is there any other information the reviewer should know?
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've reviewed the project documentation on [contributing](https://skbase.readthedocs.io/en/latest/contribute.html)
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skbase/blob/main/.all-contributorsrc).
- [ ] The PR title starts with either [ENH], [CI/CD], [MNT], [DOC], or [BUG] indicating whether
  the PR topic is related to enhancement, CI/CD, maintenance, documentation, or a bug.

##### For code contributions
- [ ] Unit tests have been added covering code functionality
- [ ] Appropriate docstrings have been added (see [documentation standards](https://skbase.readthedocs.io/en/latest/contribute/development/developer_guide/creating_docs.html))
- [ ] New public functionality has been added to the API Reference


<!--
Thanks for contributing!
-->
