### PR TITLE
[ENH] ensure _get_installed_packages does not break in case of empty package metadata

### DIFF
--- a/skbase/utils/dependencies/_dependencies.py
+++ b/skbase/utils/dependencies/_dependencies.py
@@ -292,7 +292,9 @@ def _get_installed_packages_private(lowercase=False):
     dists = distributions()
     dists = {dist for dist in dists if dist.metadata is not None}
     package_names = {dist.metadata.get("Name") for dist in dists}
-    package_versions = {pkg_name: version(pkg_name) for pkg_name in package_names if pkg_name}
+    package_versions = {
+        pkg_name: version(pkg_name) for pkg_name in package_names if pkg_name
+    }
     # developer note:
     # we cannot just use distributions naively,
     # because the same top level package name may appear *twice*,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skbase.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs

#433

<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Some broken packages with empty `.egg-info` folder, will result in empty metadata, which will give `None` as pkg name and cause `ValueError("A distribution name is required.")` in `Distribution.from_name`

Added some simple filters to ignore them.
<!--
A clear and concise description of what you have implemented. Remember to implement
unit tests and docstrings if your pull request commits code to the repository.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

No
<!--
If your contribution requires a new dependency please indicate why it is necessary.
skbase seeks to minimize dependencies to make it easy to use skbase in a variety
of environments and contexts.
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development.
You can guide the reviews to focus on the parts that are ready for their comments.
We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Any other comments?
<!--
Is there any other information the reviewer should know?
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've reviewed the project documentation on [contributing](https://skbase.readthedocs.io/en/latest/contribute.html)
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skbase/blob/main/.all-contributorsrc).
- [x] The PR title starts with either [ENH], [CI/CD], [MNT], [DOC], or [BUG] indicating whether
  the PR topic is related to enhancement, CI/CD, maintenance, documentation, or a bug.

##### For code contributions
- [ ] Unit tests have been added covering code functionality
- [ ] Appropriate docstrings have been added (see [documentation standards](https://skbase.readthedocs.io/en/latest/contribute/development/developer_guide/creating_docs.html))
- [ ] New public functionality has been added to the API Reference


<!--
Thanks for contributing!
-->
