### PR TITLE
[MNT] add precommit skip for `delattr` use in test

### DIFF
--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -386,7 +386,7 @@ def test_set_tags_works_with_missing_tags_dynamic_attribute(
 ):
     """Test set_tags will still work if _tags_dynamic is missing."""
     base_obj = deepcopy(fixture_tag_class_object)
-    delattr(base_obj, "_tags_dynamic")
+    delattr(base_obj, "_tags_dynamic")  # noqa: B043
     assert not hasattr(base_obj, "_tags_dynamic")
     base_obj.set_tags(some_tag="something")
     tags = base_obj.get_tags()


### PR DESCRIPTION
adds a precommit skip for a single `delattr` use in tests