### PR TITLE
[ENH] Catch expected FutureWarnings in test_tag_aliaser

### DIFF
--- a/skbase/tests/test_tagaliaser.py
+++ b/skbase/tests/test_tagaliaser.py
@@ -43,7 +43,9 @@ def test_tag_aliaser():
     """Tests the tag aliaser logic, as described in its docstring."""
     # case both new and old tags exist
     # old tag takes precedence
-    with pytest.warns(FutureWarning, match=_tag_deprecation_regex("old_tag_1", "new_tag_1")):
+    with pytest.warns(
+        FutureWarning, match=_tag_deprecation_regex("old_tag_1", "new_tag_1")
+    ):
         new_tag_1_val = AliaserTestClass().get_tag("new_tag_1")
         assert new_tag_1_val == "old_tag_1_value"
         old_tag_1_val = AliaserTestClass().get_tag("old_tag_1")
@@ -55,7 +57,9 @@ def test_tag_aliaser():
         assert old_tag_1_val == "old_tag_1_value"
 
     # case only new tag exists
-    with pytest.warns(FutureWarning, match=_tag_deprecation_regex("old_tag_2", "new_tag_2")):
+    with pytest.warns(
+        FutureWarning, match=_tag_deprecation_regex("old_tag_2", "new_tag_2")
+    ):
         new_tag_2_val = AliaserTestClass().get_tag("new_tag_2")
         assert new_tag_2_val == "new_tag_2_value"
         old_tag_2_val = AliaserTestClass().get_tag("old_tag_2")
@@ -67,7 +71,9 @@ def test_tag_aliaser():
         assert old_tag_2_val == "new_tag_2_value"
 
     # case only old tag exists
-    with pytest.warns(FutureWarning, match=_tag_deprecation_regex("old_tag_3", "new_tag_3")):
+    with pytest.warns(
+        FutureWarning, match=_tag_deprecation_regex("old_tag_3", "new_tag_3")
+    ):
         new_tag_3_val = AliaserTestClass().get_tag("new_tag_3")
         assert new_tag_3_val == "old_tag_3_value"
         old_tag_3_val = AliaserTestClass().get_tag("old_tag_3")
@@ -95,4 +101,3 @@ def test_tag_aliaser():
         assert all_tags_cls["old_tag_2"] == "new_tag_2_value"
         assert all_tags_cls["new_tag_3"] == "old_tag_3_value"
         assert all_tags_cls["old_tag_3"] == "old_tag_3_value"
-        


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #497

#### What does this implement/fix? Explain your changes.
This PR resolves an issue in `skbase/tests/test_tagaliaser.py::test_tag_aliaser` where 10 expected `FutureWarning` messages were leaking into the pytest console output.

The test correctly interacts with deprecated tags to verify the `AliaserTestClass` logic, which naturally triggers these warnings. This PR wraps the assertions inside a `with pytest.warns(FutureWarning):` context manager to explicitly catch and validate the warnings, keeping the test suite output clean.

#### Does your contribution introduce a new dependency? If yes, which one?
No new dependencies.

#### What should a reviewer concentrate their feedback on?
- The implementation of the `pytest.warns(FutureWarning)` context manager in `test_tag_aliaser`.

#### Any other comments?
Tested locally using `pytest`. The 10 leaking warnings have been successfully caught and cleared from the test summary.

#### PR checklist

##### For all contributions
- [x] I've reviewed the project documentation on [contributing](https://skbase.readthedocs.io/en/latest/contribute.html)
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skbase/blob/main/.all-contributorsrc).
- [x] The PR title starts with either [ENH], [CI/CD], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, CI/CD, maintenance, documentation, or a bug.

##### For code contributions
- [x] Unit tests have been added covering code functionality
- [ ] Appropriate docstrings have been added 
- [ ] New public functionality has been added to the API Reference