### PR TITLE
ENH: update html parameter display to match scikit-learn style

### DIFF
--- a/skbase/base/_pretty_printing/_object_html_repr.py
+++ b/skbase/base/_pretty_printing/_object_html_repr.py
@@ -74,7 +74,7 @@ def _params_to_html_table(estimator):
         The estimator whose ``get_params(deep=False)`` will be used.
 
     Returns
-
+    -------
     str
         HTML string of a ``<table>`` element, or empty string when the
         estimator has no parameters or no ``get_params`` method.


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #503. Related to sktime/sktime#9497.

#### What does this implement/fix? Explain your changes.
scikit-learn has updated how they display parameters in the HTML representation of estimators. This PR updates scikit-base to match.

Previously, clicking an estimator box in a Jupyter notebook showed a raw `<pre>` string like `MyEstimator(alpha=0.5)`. 

This PR replaces that with a structured two-column parameter table built from `get_params(deep=False)`, showing each parameter name and its current value in a cleaner, more readable format.

Changes:
- New _params_to_html_table() helper that generates the table HTML
- _write_label_html() gains an optional estimator parameter; when provided, renders the table instead of the pre block
- _write_base_object_html() passes the estimator through
- CSS styles for the table appended to _STYLE

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- The CSS styling choices for the parameter table
- Whether the fallback to `<pre>` for non-estimator objects is correct

#### Any other comments?
Marked as Draft, happy to add unit tests once the approach is confirmed as the right direction.

#### How it looks like:
<img width="334" height="168" alt="Screenshot 2026-03-25 152701" src="https://github.com/user-attachments/assets/06cd15c3-1135-403b-bd9c-71a1ca184f5d" />

