### PR TITLE
MNT: add numpydoc validation to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Validate numpydoc
         run: python -m numpydoc.validate skbase --errors-only
-        
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
### MNT: Add numpydoc validation to CI

This PR adds a numpydoc validation step to the CI workflow to ensure that docstrings in `skbase` follow the numpydoc standard.

The workflow runs:

`python -m numpydoc.validate skbase`

Closes #146
