### PR TITLE
[MNT] Add py.typed marker file for PEP 561 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ exclude_dirs = ["*/tests/*", "*/testing/*"]
 zip-safe = true
 
 [tool.setuptools.package-data]
+skbase = ["py.typed"]
 sktime = [
     "*.csv",
     "*.csv.gz",
@@ -156,3 +157,9 @@ sktime = [
 
 [tool.setuptools.packages.find]
 exclude = ["tests", "tests.*"]
+
+[tool.mypy]
+python_version = "3.10"
+packages = ["skbase"]
+ignore_missing_imports = true
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,4 +162,3 @@ exclude = ["tests", "tests.*"]
 python_version = "3.10"
 packages = ["skbase"]
 ignore_missing_imports = true
-

--- a/skbase/tests/test_installation.py
+++ b/skbase/tests/test_installation.py
@@ -1,0 +1,16 @@
+"""Tests for skbase package installation and compliance."""
+
+import os
+
+import skbase
+
+
+def test_py_typed_marker_exists():
+    """Test that py.typed marker file exists for PEP 561 compliance."""
+    package_dir = os.path.dirname(skbase.__file__)
+    py_typed_path = os.path.join(package_dir, "py.typed")
+    assert os.path.isfile(py_typed_path), (
+        "py.typed marker file is missing from skbase package. "
+        "This file is required for PEP 561 compliance so that "
+        "mypy and pyright can use skbase's type annotations."
+    )


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #528 

#### What does this implement/fix? Explain your changes.

skbase had type hints throughout the codebase but was missing the 
`py.typed` marker file required by PEP 561. Without this file, type 
checkers like `mypy` and `pyright` silently skip all type annotations 
in skbase when used as an installed package, meaning downstream packages 
(sktime, skpro, etc.) got zero type checking benefit.

Changes made:
- Created empty `skbase/py.typed` marker file (PEP 561 requirement)
- Updated `pyproject.toml` to include `py.typed` in package data so 
  it is bundled correctly in the distribution
- Added `[tool.mypy]` config in `pyproject.toml` to enable mypy 
  to recognize skbase as a typed package
- Added regression test in `skbase/tests/test_installation.py` to 
  ensure `py.typed` is always present in the installed package

Before this fix mypy reported:
  Skipping analyzing 'skbase': module is installed, but missing 
  library stubs or py.typed marker

After this fix mypy correctly picks up all skbase type annotations.

#### Does your contribution introduce a new dependency? If yes, which one?

No new dependencies introduced. This is a single empty marker file 
plus a small config change.

#### What should a reviewer concentrate their feedback on?

- `pyproject.toml` changes — is the `package-data` config correct 
  for the build backend being used (setuptools/hatchling)?
- The regression test in `test_installation.py` — is this the right 
  place for it or should it live elsewhere?
- Verify `py.typed` is correctly bundled by checking:
  `unzip -l dist/*.whl | grep py.typed`

#### Any other comments?

PEP 561 states: "Package maintainers who wish to support type checking 
of their code MUST add a marker file named py.typed to their package."

Since skbase is explicitly designed as a base framework for building 
typed, scikit-learn-like packages, PEP 561 compliance is especially 
important — the entire downstream ecosystem of skbase users is affected 
by this missing marker. This is a minimal, zero-risk change — one empty 
file and a few config lines.

Reference: https://peps.python.org/pep-0561/

#### PR checklist

##### For all contributions
- [x] I've reviewed the project documentation on [contributing](https://skbase.readthedocs.io/en/latest/contribute.html)
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skbase/blob/main/.all-contributorsrc).
- [x] The PR title starts with either [ENH], [CI/CD], [MNT], [DOC], or [BUG] indicating whether
  the PR topic is related to enhancement, CI/CD, maintenance, documentation, or a bug.

##### For code contributions
- [ ] Unit tests have been added covering code functionality
- [ ] Appropriate docstrings have been added (see [documentation standards](https://skbase.readthedocs.io/en/latest/contribute/development/developer_guide/creating_docs.html))
- [ ] New public functionality has been added to the API Reference