### PR TITLE
[MNT] fix 0.13.2 release version in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scikit-base"
-version = "0.13.1"
+version = "0.13.2"
 description = "Base classes for sklearn-like parametric objects"
 authors = [
     {name = "sktime developers", email = "sktime.toolbox@gmail.com"},


### PR DESCRIPTION
Accidentally, `pyproject.toml` was not pushed for the 0.13.2 release.

No upload happened since the CI caught the inconsistency - this just needs to get fixed.