### PR TITLE
[MNT] update release workflow to simplified setup

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -96,7 +96,7 @@ jobs:
         run: echo "WHEELNAME=$(ls ./wheelhouse/sktime-*none-any.whl)" >> $env:GITHUB_ENV
 
       - name: Install wheel and extras
-        run: python3 -m pip install "${{ env.WHEELNAME }}[all_extras,dev]"
+        run: python -m pip install "${{ env.WHEELNAME }}[all_extras,dev]"
 
       - name: Run tests
         run: python -m pytest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -89,11 +89,11 @@ jobs:
       # Set wheel filename differently for Unix vs Windows
       - name: Get wheel filename (Unix)
         if: runner.os != 'Windows'
-        run: echo "WHEELNAME=$(ls ./wheelhouse/sktime-*none-any.whl)" >> $GITHUB_ENV
+        run: echo "WHEELNAME=$(ls ./wheelhouse/scikit-base-*none-any.whl)" >> $GITHUB_ENV
 
       - name: Get wheel filename (Windows)
         if: runner.os == 'Windows'
-        run: echo "WHEELNAME=$(ls ./wheelhouse/sktime-*none-any.whl)" >> $env:GITHUB_ENV
+        run: echo "WHEELNAME=$(ls ./wheelhouse/scikit-base-*none-any.whl)" >> $env:GITHUB_ENV
 
       - name: Install wheel and extras
         run: python3 -m pip install "${{ env.WHEELNAME }}[all_extras,dev]"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -39,14 +39,21 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       - name: Build wheel
         run: |
-          python -m pip install build
-          python -m build --wheel --sdist --outdir wheelhouse
+          uv pip install build
+          uv build --wheel --sdist --out-dir wheelhouse
+        env:
+          UV_SYSTEM_PYTHON: 1
 
       - name: Store wheels
         uses: actions/upload-artifact@v7
@@ -54,17 +61,19 @@ jobs:
           name: wheels
           path: wheelhouse/*
 
-  test_unix_wheels:
+  test_wheels:
     needs: build_wheels
     name: Test wheels on ${{ matrix.os }} with ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false  # to not fail all combinations if just one fail
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v6
+
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
@@ -74,93 +83,28 @@ jobs:
           name: wheels
           path: wheelhouse
 
-      - name: Get wheel filename
-        run: echo "WHEELNAME=$(ls ./wheelhouse/scikit_base-*none-any.whl)" >> $GITHUB_ENV
-
-      - name: Install wheel and extras
-        run: python -m pip install "${{ env.WHEELNAME }}[all_extras,dev]"
-
-      - name: Run tests
-        run: |
-          python -m pytest
-
-  test_windows_wheels:
-    needs: build_wheels
-    name: Test wheels on ${{ matrix.os }} with ${{ matrix.python-version }}
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        include:
-          # Window 64 bit
-          - os: windows-latest
-            python: 310
-            python-version: '3.10'
-            bitness: 64
-            platform_id: win_amd64
-          - os: windows-latest
-            python: 311
-            python-version: "3.11"
-            bitness: 64
-            platform_id: win_amd64
-          - os: windows-latest
-            python: 312
-            python-version: "3.12"
-            bitness: 64
-            platform_id: win_amd64
-          - os: windows-latest
-            python: 313
-            python-version: "3.13"
-            bitness: 64
-            platform_id: win_amd64
-          - os: windows-latest
-            python: 313
-            python-version: "3.14"
-            bitness: 64
-            platform_id: win_amd64
-
-    steps:
-      - uses: actions/checkout@v6
-      - uses: conda-incubator/setup-miniconda@v3
-        with:
-          activate-environment: test
-          auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
-          channels: anaconda, conda-forge,
-
-      - run: conda --version
-      - run: which python
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: wheels
-          path: wheelhouse
-
-      - name: Install conda libpython
-        run: conda install -c anaconda -n test -y libpython
-
       - name: Display downloaded artifacts
         run: ls -l wheelhouse
 
-      - name: Get wheel filename
-        run: echo "WHEELNAME=$(ls ./wheelhouse/scikit_base-*none-any.whl)" >> $env:GITHUB_ENV
+      # Set wheel filename differently for Unix vs Windows
+      - name: Get wheel filename (Unix)
+        if: runner.os != 'Windows'
+        run: echo "WHEELNAME=$(ls ./wheelhouse/sktime-*none-any.whl)" >> $GITHUB_ENV
 
-      - name: Activate conda env
-        run: conda activate test
+      - name: Get wheel filename (Windows)
+        if: runner.os == 'Windows'
+        run: echo "WHEELNAME=$(ls ./wheelhouse/sktime-*none-any.whl)" >> $env:GITHUB_ENV
 
       - name: Install wheel and extras
-        run: python -m pip install "${env:WHEELNAME}[all_extras,dev]"
-
-      - name: Show conda packages
-        run: conda list -n test
+        run: python3 -m pip install "${{ env.WHEELNAME }}[all_extras,dev]"
 
       - name: Run tests
-        run: |
-          python -m pytest
+        run: python -m pytest
 
   upload_wheels:
     name: Upload wheels to PyPI
     runs-on: ubuntu-latest
-    needs: [build_wheels,test_unix_wheels,test_windows_wheels]
+    needs: [build_wheels,test_wheels]
 
     permissions:
       id-token: write

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -66,7 +66,7 @@ jobs:
     name: Test wheels on ${{ matrix.os }} with ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false  # to not fail all combinations if just one fail
+      fail-fast: false  # to not fail all combinations if just one fails
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -89,11 +89,11 @@ jobs:
       # Set wheel filename differently for Unix vs Windows
       - name: Get wheel filename (Unix)
         if: runner.os != 'Windows'
-        run: echo "WHEELNAME=$(ls ./wheelhouse/scikit-base-*none-any.whl)" >> $GITHUB_ENV
+        run: echo "WHEELNAME=$(ls ./wheelhouse/scikit_base-*none-any.whl)" >> $GITHUB_ENV
 
       - name: Get wheel filename (Windows)
         if: runner.os == 'Windows'
-        run: echo "WHEELNAME=$(ls ./wheelhouse/scikit-base-*none-any.whl)" >> $env:GITHUB_ENV
+        run: echo "WHEELNAME=$(ls ./wheelhouse/scikit_base-*none-any.whl)" >> $env:GITHUB_ENV
 
       - name: Install wheel and extras
         run: python3 -m pip install "${{ env.WHEELNAME }}[all_extras,dev]"


### PR DESCRIPTION
This PR updates the release workflow to a more simplified and standardized setup:

* single `test_wheels` job instead of one per operating system
* remove `anaconda` environment, use `uv`
* use same workflow as in `sktime`