### PR TITLE
[BUG] Fix in-place mutation in make_strings_unique

### DIFF
--- a/skbase/utils/_iter.py
+++ b/skbase/utils/_iter.py
@@ -210,7 +210,7 @@ def make_strings_unique(str_list):
     str_count = collections.Counter(str_list)
     # if any duplicates, we append _integer of occurrence to non-uniques
     now_count: collections.Counter = collections.Counter()
-    unique_strs = str_list
+    unique_strs = list(str_list)
     for i, x in enumerate(unique_strs):
         if str_count[x] > 1:
             now_count.update([x])

--- a/skbase/utils/tests/test_iter.py
+++ b/skbase/utils/tests/test_iter.py
@@ -134,9 +134,7 @@ def test_make_strings_unique_immutable_input():
     input_list = ["abc", "abc", "bcd"]
     input_copy = list(input_list)
     make_strings_unique(input_list)
-    assert (
-        input_list == input_copy
-    ), "make_strings_unique mutated its input flat list!"
+    assert input_list == input_copy, "make_strings_unique mutated its input flat list!"
 
     # Test with a nested list structure
     nested_list = [["abc", "abc"], "bcd"]
@@ -145,4 +143,3 @@ def test_make_strings_unique_immutable_input():
     assert (
         nested_list == nested_copy
     ), "make_strings_unique mutated its input nested list!"
-

--- a/skbase/utils/tests/test_iter.py
+++ b/skbase/utils/tests/test_iter.py
@@ -126,3 +126,23 @@ def test_make_strings_unique_output():
     # Case when input is not flat
     some_strs = ["abc_1", ("abc_2", "bcd")]
     assert make_strings_unique(some_strs) == ["abc_1", ("abc_2", "bcd")]
+
+
+def test_make_strings_unique_immutable_input():
+    """Test that make_strings_unique does not mutate its input in-place."""
+    # Test with a flat list containing duplicates
+    input_list = ["abc", "abc", "bcd"]
+    input_copy = list(input_list)
+    make_strings_unique(input_list)
+    assert (
+        input_list == input_copy
+    ), "make_strings_unique mutated its input flat list!"
+
+    # Test with a nested list structure
+    nested_list = [["abc", "abc"], "bcd"]
+    nested_copy = [["abc", "abc"], "bcd"]
+    make_strings_unique(nested_list)
+    assert (
+        nested_list == nested_copy
+    ), "make_strings_unique mutated its input nested list!"
+


### PR DESCRIPTION
Fixes #551

The function `make_strings_unique` was mutating the input list in-place due to a direct reference assignment. This PR ensures a copy is created before modification.

Verified with a reproduction script:
```python
mylist = ["a", "b", "a"]
make_strings_unique(mylist)
# mylist remains ["a", "b", "a"]
```