### PR TITLE
[ENH] experimental `get_tag` hybrid method callable on class and instance

### DIFF
--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -64,6 +64,7 @@ from skbase._exceptions import NotFittedError
 from skbase.base._clone_base import _check_clone, _clone
 from skbase.base._pretty_printing._object_html_repr import _object_html_repr
 from skbase.base._tagmanager import _FlagManager
+from skbase.utils._hybridmethod import hybridmethod
 
 __author__: List[str] = ["fkiraly", "mloning", "RNKuhns", "tpvasconcelos"]
 __all__: List[str] = ["BaseEstimator", "BaseObject"]
@@ -204,7 +205,7 @@ class BaseObject(_FlagManager):
 
         Returns
         -------
-        list of str
+        list of BaseCloner descendants, default = None
             List of clone plugins for descendants.
             Each plugin must inherit from ``BaseCloner``
             in ``skbase.base._clone_plugins``, and implement
@@ -567,6 +568,7 @@ class BaseObject(_FlagManager):
             flag_attr_name="_tags",
         )
 
+    @hybridmethod
     def get_tags(self):
         """Get tags from instance, with tag level inheritance and overrides.
 
@@ -599,8 +601,13 @@ class BaseObject(_FlagManager):
             class attribute via nested inheritance and then any overrides
             and new tags from ``_tags_dynamic`` object attribute.
         """
+        if isinstance(self, type):
+            # if called on class, return class tags
+            return self.get_class_tags()
+        # if called on instance, return instance tags with overrides
         return self._get_flags(flag_attr_name="_tags")
 
+    @hybridmethod
     def get_tag(self, tag_name, tag_value_default=None, raise_error=True):
         """Get tag value from instance, with tag level inheritance and overrides.
 
@@ -645,6 +652,12 @@ class BaseObject(_FlagManager):
             The ``ValueError`` is then raised if ``tag_name`` is
             not in ``self.get_tags().keys()``.
         """
+        if isinstance(self, type):
+            # if called on class, return class tag
+            return self.get_class_tag(
+                tag_name=tag_name,
+                tag_value_default=tag_value_default,
+            )
         return self._get_flag(
             flag_name=tag_name,
             flag_value_default=tag_value_default,

--- a/skbase/utils/_hybridmethod.py
+++ b/skbase/utils/_hybridmethod.py
@@ -7,10 +7,12 @@ class hybridmethod:
     The decorated method will receive the class as the first argument when called
     on the class, and the instance when called on an instance.
     """
+
     def __init__(self, func):
         self.func = func
 
     def __get__(self, obj, cls):
         def wrapper(*args, **kwargs):
             return self.func(obj if obj is not None else cls, *args, **kwargs)
+
         return wrapper

--- a/skbase/utils/_hybridmethod.py
+++ b/skbase/utils/_hybridmethod.py
@@ -11,6 +11,7 @@ class hybridmethod:
         self.func = func
 
     def __get__(self, obj, cls):
+        """Get method that can be called on both class and instance."""
         def wrapper(*args, **kwargs):
             return self.func(obj if obj is not None else cls, *args, **kwargs)
         return wrapper

--- a/skbase/utils/_hybridmethod.py
+++ b/skbase/utils/_hybridmethod.py
@@ -13,6 +13,7 @@ class hybridmethod:
 
     def __get__(self, obj, cls):
         """Get method that can be called on both class and instance."""
+
         def wrapper(*args, **kwargs):
             return self.func(obj if obj is not None else cls, *args, **kwargs)
 

--- a/skbase/utils/_hybridmethod.py
+++ b/skbase/utils/_hybridmethod.py
@@ -1,0 +1,16 @@
+"""Decorator for methods that can be called both on the class and on instances."""
+
+
+class hybridmethod:
+    """Decorator for methods that can be called both on the class and on instances.
+
+    The decorated method will receive the class as the first argument when called
+    on the class, and the instance when called on an instance.
+    """
+    def __init__(self, func):
+        self.func = func
+
+    def __get__(self, obj, cls):
+        def wrapper(*args, **kwargs):
+            return self.func(obj if obj is not None else cls, *args, **kwargs)
+        return wrapper

--- a/skbase/utils/dependencies/_import.py
+++ b/skbase/utils/dependencies/_import.py
@@ -23,7 +23,6 @@ def _safe_import(import_path, pkg_name=None, condition=True, return_object="Magi
 
     Example: ``clone = _safe_import("sklearn.clone", pkg_name="scikit-learn")``.
 
-
     Parameters
     ----------
     import_path : str

--- a/skbase/utils/tests/test_hybridmethod.py
+++ b/skbase/utils/tests/test_hybridmethod.py
@@ -1,0 +1,29 @@
+"""Tests for hybridmethod decorator."""
+
+from inspect import isclass
+
+from skbase.utils._hybridmethod import hybridmethod
+
+
+class HybridmethodTestclass:
+
+    def __init__(self):
+        self.ref_to_self = self
+
+    @hybridmethod
+    def method(self_or_cls):
+
+        if isclass(self_or_cls):
+            assert self_or_cls is self_or_cls.ref_to_self
+        else:
+            assert self_or_cls is self_or_cls.ref_to_self
+            assert isinstance(self_or_cls, self_or_cls.__class__)
+
+
+HybridmethodTestclass.ref_to_self = HybridmethodTestclass
+
+
+def test_hybridmethod():
+    """Test that hybridmethod works as expected."""
+    HybridmethodTestclass.method()
+    HybridmethodTestclass().method()

--- a/skbase/utils/tests/test_hybridmethod.py
+++ b/skbase/utils/tests/test_hybridmethod.py
@@ -11,13 +11,13 @@ class HybridmethodTestclass:
         self.ref_to_self = self
 
     @hybridmethod
-    def method(self_or_cls):
+    def method(self):
 
-        if isclass(self_or_cls):
-            assert self_or_cls is self_or_cls.ref_to_self
+        if isclass(self):
+            assert self is self.ref_to_self
         else:
-            assert self_or_cls is self_or_cls.ref_to_self
-            assert isinstance(self_or_cls, self_or_cls.__class__)
+            assert self is self.ref_to_self
+            assert isinstance(self, self.__class__)
 
 
 HybridmethodTestclass.ref_to_self = HybridmethodTestclass


### PR DESCRIPTION
This PR is an experimental design study that modifies `get_tag` and `get_tags` methods of `BaseObject` so it is callable on classes as well as on instances.

In the current case, `get_tag` gets rerouted to `get_class_tag` if called on a class, and `get_tags` similarly to `get_class_tags`.

Ultimately, this could allow `get_tag` and `get_tags` as the single interface point for tags.