### PR TITLE
[ENH] safer `get_params(deep=True)` nesting

### DIFF
--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -330,13 +330,28 @@ class BaseObject(_FlagManager):
         """
         params = {key: getattr(self, key) for key in self.get_param_names()}
 
-        if deep:
-            deep_params = {}
-            for key, value in params.items():
-                if hasattr(value, "get_params"):
-                    deep_items = value.get_params().items()
-                    deep_params.update({f"{key}__{k}": val for k, val in deep_items})
-            params.update(deep_params)
+        if not deep:
+            return params
+
+        # we know deep=True, so recurse
+        deep_params = {}
+        for key, value in params.items():
+            # Skip class objects (e.g. BaseObject subclasses stored as params);
+            # only recurse into instances with a valid get_params method.
+            if isclass(value):
+                continue
+
+            get_params = getattr(value, "get_params", None)
+            if not callable(get_params):
+                continue
+
+            params = get_params()
+            if not isinstance(params, dict):
+                continue
+
+            deep_params.update({f"{key}__{k}": v for k, v in params.items()})
+
+        params.update(deep_params)
 
         return params
 

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -58,6 +58,7 @@ import re
 import warnings
 from collections import defaultdict
 from copy import deepcopy
+from inspect import isclass
 from typing import List
 
 from skbase._exceptions import NotFittedError

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -346,11 +346,11 @@ class BaseObject(_FlagManager):
             if not callable(get_params):
                 continue
 
-            params = get_params()
-            if not isinstance(params, dict):
+            sub_params = get_params()
+            if not isinstance(sub_params, dict):
                 continue
 
-            deep_params.update({f"{key}__{k}": v for k, v in params.items()})
+            deep_params.update({f"{key}__{k}": v for k, v in sub_params.items()})
 
         params.update(deep_params)
 

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -1518,3 +1518,31 @@ def test_get_class_tags_diamond_inheritance():
     obj = Diamond()
     assert obj.get_tag("A", raise_error=False) == 42
     assert obj.get_tag("B", raise_error=False) == 2
+
+
+class BadGetParamsClass:
+
+    get_params = "This is not a method in order to test get_params nesting handling."
+
+
+class NestedBadGetParamsTester(BaseObject):
+    """Class for testing get_params functionality."""
+
+    clsvar = 210
+
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+        super().__init__()
+
+
+def test_get_params_with_nested_bad_get_params():
+    """Test that get_params works when nested get_params is not method."""
+    nested_bad_get_params = BadGetParamsClass()
+    obj = NestedBadGetParamsTester(a=7, b=nested_bad_get_params)
+
+    # this should not raise an error
+    # error mode is attenpting to call get_params of nested_bad_get_params,
+    # which is a string, instead of the get_params of the parent object
+    # instead, get_params should recognize the string type and not call it
+    obj.get_params(deep=True)


### PR DESCRIPTION
This PR makes the `get_params` branch for `deep=True` safer, i.e., recursion into component `get_params` calls.

It avoids failure if `get_params` is present, but it is not an instance method that returns a `dict`.

Also adds a regression test that would trigger the previous "unsafe" behaviour.