### PR TITLE
[MNT] add integration testing for `pandas 3`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,10 +142,15 @@ jobs:
             python-version: "3.10"
             exclude_newer: "2023-01-01"
 
-          # pandas 2.x era (pandas 2.0 was April 2023)
+          # pandas 2.x era (pandas 2.0 released April 2023)
           - name: "pandas-2"
             python-version: "3.10"
             exclude_newer: "2024-06-01"
+
+          # pandas 3.x era (pandas 3.0 released Jan 2026)
+          - name: "pandas-3"
+            python-version: "3.12"
+            exclude_newer: "2026-06-01"
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Adds a CI run of integration tests that ensures `pandas 3`.