### PR TITLE
[ENH] early return for `deep_equals` in case of object identity

### DIFF
--- a/skbase/tests/test_deep_equals.py
+++ b/skbase/tests/test_deep_equals.py
@@ -1,8 +1,9 @@
+from skbase.utils.deep_equals import deep_equals
+
+
 def test_deep_equals_numpy_string_array():
     """Test that deep_equals works on string-dtype numpy arrays. GitHub issue #517."""
     import numpy as np
-
-    from skbase.utils.deep_equals import deep_equals
 
     s = np.array(["1", "2", "1"])
     # Same arrays should be equal
@@ -11,3 +12,24 @@ def test_deep_equals_numpy_string_array():
     # Different arrays should not be equal
     t = np.array(["1", "2", "3"])
     assert deep_equals(s, t) is False
+
+
+def test_deep_equals_equal_object():
+    class DummyComposite:
+        def __init__(self, func1, func2, neq_called):
+            self.func1 = func1
+            self.func2 = func2
+            self.neq_called = neq_called
+
+    class Dummy:
+        def __init__(self, func):
+            self.func = func
+
+        def __eq__(self, other) -> DummyComposite:
+            return DummyComposite(self.func, other.func, False)
+
+        def __ne__(self, other) -> DummyComposite:
+            return DummyComposite(self.func, other.func, True)
+
+    a = Dummy(lambda x: x)
+    assert deep_equals(a, a)

--- a/skbase/utils/deep_equals/_deep_equals.py
+++ b/skbase/utils/deep_equals/_deep_equals.py
@@ -508,6 +508,9 @@ def deep_equals_custom(x, y, return_msg=False, plugins=None):
     """
     ret = _make_ret(return_msg)
 
+    if x is y:
+        return ret(True, "")
+
     if type(x) is not type(y):
         return ret(False, f".type, x.type = {type(x)} != y.type = {type(y)}")
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skbase.readthedocs.io/en/latest/contribute.html
-->
This fixes the following problem


```python
    from pytorch_forecasting.metrics.quantile import QuantileLoss
    import numpy as np

    a = QuantileLoss(quantiles=[0.1, 0.2])
    assert deep_equals(a, a)  # Fails
```
this fails since the `QuantileLoss` overwrites `__eq__` and `__ne__`. I simulate this in a test that fails on main as well, in order to not introduce another heavy dependency.


#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented. Remember to implement
unit tests and docstrings if your pull request commits code to the repository.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution requires a new dependency please indicate why it is necessary.
skbase seeks to minimize dependencies to make it easy to use skbase in a variety
of environments and contexts.
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development.
You can guide the reviews to focus on the parts that are ready for their comments.
We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Any other comments?
<!--
Is there any other information the reviewer should know?
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've reviewed the project documentation on [contributing](https://skbase.readthedocs.io/en/latest/contribute.html)
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skbase/blob/main/.all-contributorsrc).
- [ ] The PR title starts with either [ENH], [CI/CD], [MNT], [DOC], or [BUG] indicating whether
  the PR topic is related to enhancement, CI/CD, maintenance, documentation, or a bug.

##### For code contributions
- [x] Unit tests have been added covering code functionality
- ~[ ] Appropriate docstrings have been added (see [documentation standards](https://skbase.readthedocs.io/en/latest/contribute/development/developer_guide/creating_docs.html))~
- ~[ ] New public functionality has been added to the API Reference~


<!--
Thanks for contributing!
-->
