### PR TITLE
[MNT] fix broken `.readthedocs.yaml`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,9 +11,9 @@ python:
         - docs
         - test
 build:
-  os: ubuntu-20.04
+  os: ubuntu-lts-latest
   tools:
-    python: "3.11"
+    python: "3.12"
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
The `.readthedocs.yaml` no longer builds due to an outdated ubuntu version.

This PR fixes the ubuntu version in the readthedocs file, enabling builds.