### PR TITLE
[ENH] Cache `_get_init_signature` and `_collect_class_flags` to improve performance in repeated tag inspection

### DIFF
--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -58,6 +58,7 @@ import re
 import warnings
 from collections import defaultdict
 from copy import deepcopy
+from functools import lru_cache
 from inspect import isclass
 from typing import List
 
@@ -214,6 +215,7 @@ class BaseObject(_FlagManager):
         return None
 
     @classmethod
+    @lru_cache(maxsize=None)
     def _get_init_signature(cls):
         """Get class init signature.
 

--- a/skbase/base/_tagmanager.py
+++ b/skbase/base/_tagmanager.py
@@ -12,26 +12,26 @@ from copy import deepcopy
 from functools import lru_cache
 
 
-@lru_cache(maxsize=None)
-def _collect_class_flags_cached(cls, flag_attr_name):
-    """Walk the MRO once per (cls, flag_attr_name) and cache the result.
-
-    Returns the dict directly; callers are responsible for copying it
-    before handing it out or mutating it, since this is a shared cached
-    object.
-    """
-    collected_flags = {}
-    for parent_class in reversed(inspect.getmro(cls)):
-        if parent_class is object:
-            continue
-        if flag_attr_name in parent_class.__dict__:
-            more_flags = parent_class.__dict__[flag_attr_name]
-            collected_flags.update(more_flags)
-    return collected_flags
-
-
 class _FlagManager:
     """Mixin class for flag and configuration settings management."""
+
+    @staticmethod
+    @lru_cache(maxsize=None)
+    def _collect_class_flags_cached(cls, flag_attr_name):
+        """Walk the MRO once per (cls, flag_attr_name) and cache the result.
+
+        Returns the dict directly; callers are responsible for copying it
+        before handing it out or mutating it, since this is a shared cached
+        object.
+        """
+        collected_flags = {}
+        for parent_class in reversed(inspect.getmro(cls)):
+            if parent_class is object:
+                continue
+            if flag_attr_name in parent_class.__dict__:
+                more_flags = parent_class.__dict__[flag_attr_name]
+                collected_flags.update(more_flags)
+        return collected_flags
 
     @classmethod
     def _get_class_flags(cls, flag_attr_name="_flags"):
@@ -49,7 +49,7 @@ class _FlagManager:
             class attribute via nested inheritance. NOT overridden by dynamic
             flags set by set_flags or clone_flags.
         """
-        cached = _collect_class_flags_cached(cls, flag_attr_name)
+        cached = cls._collect_class_flags_cached(cls, flag_attr_name)
         # shallow copy: cheap, and safe because tag values are immutable
         # (they are primitives types bool, etc.)
         return dict(cached)
@@ -112,7 +112,9 @@ class _FlagManager:
             and new flags from [flag_attr_name]_dynamic object attribute.
         """
         # shallow copy of the cached class-level dict
-        collected_flags = dict(_collect_class_flags_cached(type(self), flag_attr_name))
+        collected_flags = dict(
+            self._collect_class_flags_cached(type(self), flag_attr_name)
+        )
 
         if hasattr(self, f"{flag_attr_name}_dynamic"):
             collected_flags.update(getattr(self, f"{flag_attr_name}_dynamic"))

--- a/skbase/base/_tagmanager.py
+++ b/skbase/base/_tagmanager.py
@@ -9,6 +9,25 @@ __all__ = ["_FlagManager"]
 
 import inspect
 from copy import deepcopy
+from functools import lru_cache
+
+
+@lru_cache(maxsize=None)
+def _collect_class_flags_cached(cls, flag_attr_name):
+    """Walk the MRO once per (cls, flag_attr_name) and cache the result.
+
+    Returns the dict directly; callers are responsible for copying it
+    before handing it out or mutating it, since this is a shared cached
+    object.
+    """
+    collected_flags = {}
+    for parent_class in reversed(inspect.getmro(cls)):
+        if parent_class is object:
+            continue
+        if flag_attr_name in parent_class.__dict__:
+            more_flags = parent_class.__dict__[flag_attr_name]
+            collected_flags.update(more_flags)
+    return collected_flags
 
 
 class _FlagManager:
@@ -30,19 +49,10 @@ class _FlagManager:
             class attribute via nested inheritance. NOT overridden by dynamic
             flags set by set_flags or clone_flags.
         """
-        collected_flags = {}
-
-        # To ensure flags from Mixins placed after BaseObject in the MRO are not
-        # dropped, iterate over the full MRO and skip only the `object` sentinel.
-        for parent_class in reversed(inspect.getmro(cls)):
-            if parent_class is object:
-                continue
-            if flag_attr_name in parent_class.__dict__:
-                # Check own __dict__ to avoid MRO-inherited duplicates
-                more_flags = parent_class.__dict__[flag_attr_name]
-                collected_flags.update(more_flags)
-
-        return deepcopy(collected_flags)
+        cached = _collect_class_flags_cached(cls, flag_attr_name)
+        # shallow copy: cheap, and safe because tag values are immutable
+        # (they are primitives types bool, etc.)
+        return dict(cached)
 
     @classmethod
     def _get_class_flag(
@@ -101,12 +111,13 @@ class _FlagManager:
             class attribute via nested inheritance and then any overrides
             and new flags from [flag_attr_name]_dynamic object attribute.
         """
-        collected_flags = self._get_class_flags(flag_attr_name=flag_attr_name)
+        # shallow copy of the cached class-level dict
+        collected_flags = dict(_collect_class_flags_cached(type(self), flag_attr_name))
 
         if hasattr(self, f"{flag_attr_name}_dynamic"):
             collected_flags.update(getattr(self, f"{flag_attr_name}_dynamic"))
 
-        return deepcopy(collected_flags)
+        return collected_flags
 
     def _get_flag(
         self,


### PR DESCRIPTION

#### Reference Issues/PRs
- The FlagManager was causing a lot of deepcopies for each fit/predict cycle. 
- BaseObject calle `_get_init_signature` for each `get_params`, but it is always the same.



#### What does this implement/fix? Explain your changes.
Solution: Use LRU Cache

Note, fix for FlagManager extracts it in a separate method and makes afterwards always a shallow copy. Otherwise, the class instance dict object would be changed and we would have side effects.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution requires a new dependency please indicate why it is necessary.
skbase seeks to minimize dependencies to make it easy to use skbase in a variety
of environments and contexts.
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development.
You can guide the reviews to focus on the parts that are ready for their comments.
We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Any other comments?
<!--
Is there any other information the reviewer should know?
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've reviewed the project documentation on [contributing](https://skbase.readthedocs.io/en/latest/contribute.html)
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skbase/blob/main/.all-contributorsrc).
- [ ] The PR title starts with either [ENH], [CI/CD], [MNT], [DOC], or [BUG] indicating whether
  the PR topic is related to enhancement, CI/CD, maintenance, documentation, or a bug.

##### For code contributions
- [ ] Unit tests have been added covering code functionality
- [ ] Appropriate docstrings have been added (see [documentation standards](https://skbase.readthedocs.io/en/latest/contribute/development/developer_guide/creating_docs.html))
- [ ] New public functionality has been added to the API Reference


<!--
Thanks for contributing!
-->
