### PR TITLE
[BUG] mute stderr in QuickTester.run_tests, and fix np.all generator checks

### DIFF
--- a/skbase/testing/test_all_objects.py
+++ b/skbase/testing/test_all_objects.py
@@ -342,6 +342,7 @@ class QuickTester:
         """
         from _pytest.outcomes import Skipped
 
+        from skbase.utils.stderr_mute import StderrMute
         from skbase.utils.stdout_mute import StdoutMute
 
         tests_to_run = self._check_none_str_or_list_of_str(
@@ -464,7 +465,10 @@ class QuickTester:
                 print_if_verbose(f"{key}")
 
                 try:
-                    with StdoutMute(active=verbose < 2):
+                    with (
+                        StdoutMute(active=verbose < 2),
+                        StderrMute(active=verbose < 2),
+                    ):
                         test_fun(**deepcopy(args))
                     results[key] = "PASSED"
                     print_if_verbose("PASSED")
@@ -541,7 +545,7 @@ class QuickTester:
                 obj = [obj]
             if not isinstance(obj, list):
                 raise ValueError(msg)
-            if not np.all(isinstance(x, str) for x in obj):
+            if not np.all([isinstance(x, str) for x in obj]):
                 raise ValueError(msg)
         return obj
 
@@ -715,12 +719,12 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
             f"found {type(names)}"
         )
 
-        assert np.all(isinstance(est, object_class) for est in objects), (
+        assert np.all([isinstance(est, object_class) for est in objects]), (
             "list elements of first return returned by create_test_instances_and_names "
             "all must be an instance of the class"
         )
 
-        assert np.all(isinstance(name, names) for name in names), (
+        assert np.all([isinstance(name, str) for name in names]), (
             "list elements of second return returned by create_test_instances_and_names"
             " all must be strings"
         )

--- a/skbase/testing/tests/__init__.py
+++ b/skbase/testing/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests for the skbase testing module."""

--- a/skbase/testing/tests/test_quicktester.py
+++ b/skbase/testing/tests/test_quicktester.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for QuickTester input checks and output muting."""
+
+import sys
+from typing import List
+
+import pytest
+
+from skbase.testing import BaseFixtureGenerator, QuickTester
+from skbase.tests.conftest import Parent
+
+__author__: List[str] = ["yash-sangwan"]
+
+
+class _NoisyTester(BaseFixtureGenerator, QuickTester):
+    """Minimal test class that writes to both output streams."""
+
+    def test_writes_to_streams(self, object_class):
+        """Write a marker to stdout and to stderr."""
+        sys.stdout.write("stdout-marker")
+        sys.stderr.write("stderr-marker")
+
+
+@pytest.mark.parametrize("bad", [42, ["a", 5], {"a": 1}])
+def test_check_none_str_or_list_of_str_rejects_invalid(bad):
+    """Invalid input raises; a generator passed to np.all would never raise."""
+    with pytest.raises(ValueError, match="must be None, str, or list of str"):
+        QuickTester._check_none_str_or_list_of_str(bad, var_name="x")
+
+
+@pytest.mark.parametrize(
+    "good, expected", [(None, None), ("a", ["a"]), (["a", "b"], ["a", "b"])]
+)
+def test_check_none_str_or_list_of_str_accepts_valid(good, expected):
+    """Valid input is returned, coerced to list of str."""
+    assert QuickTester._check_none_str_or_list_of_str(good, var_name="x") == expected
+
+
+@pytest.mark.parametrize("verbose, muted", [(0, True), (2, False)])
+def test_run_tests_mutes_stdout_and_stderr(capsys, verbose, muted):
+    """Both streams are muted below verbose=2, and both are shown at verbose=2."""
+    _NoisyTester().run_tests(
+        Parent, tests_to_run="test_writes_to_streams", verbose=verbose
+    )
+    captured = capsys.readouterr()
+    assert ("stdout-marker" not in captured.out) is muted
+    assert ("stderr-marker" not in captured.err) is muted


### PR DESCRIPTION
#### Reference Issues/PRs

Spun out of the `sktime` test framework refactor (#10647), specifically PR #10862 which inherits `BaseFixtureGenerator` and `QuickTester` from `skbase.testing`. @fkiraly suggested upstreaming the `StderrMute` change there.

#### What does this implement/fix? Explain your changes.

This introduces two independent fixes in `skbase/testing/test_all_objects.py`, both found while making `sktime` inherit this test framework.

**1. `run_tests` only muted stdout**

Currently, `run_tests` wraps each test in `StdoutMute(active=verbose < 2)`, so anything a test writes to stderr still reaches the log at `verbose=0`. `sktime` has been muting both streams since PR #8799, so inheriting `run_tests` unchanged would have silently dropped the stderr half. `StderrMute` already shipped in `skbase.utils.stderr_mute`, it was just never used here.

Measured before and after:

| | stdout leak | stderr leak |
| --- | --- | --- |
| before, `verbose=0` | 0 | 1 |
| after, `verbose=0` | 0 | 0 |
| after, `verbose=2` | 1 | 1 |

`verbose=2` still shows both streams, so the escape hatch is unchanged.

**2. Three checks passed a generator expression to `np.all`**

For example:
```python
if not np.all(isinstance(x, str) for x in obj):

```

Without brackets, this is a generator expression. `np.all` receives a single generator object rather than an array of booleans. NumPy treats it as one scalar object and applies truthiness, and every generator object is truthy. The result is unconditionally `True`, the generator is never consumed, and the check never fires.

Affected areas:

* `QuickTester._check_none_str_or_list_of_str`: `tests_to_run`, `fixtures_to_run`, and related args were effectively unvalidated.
* Both checks in `TestAllObjects.test_create_test_instances_and_names`.

There is a secondary bug in the last of these. It read:

```python
assert np.all(isinstance(name, names) for name in names), "... all must be strings"

```

Since `names` is a list of strings, not a type, `isinstance(name, names)` is invalid and raises a `TypeError`. The generator bug was masking it. Adding brackets alone would have converted a silently passing assert into a hard `TypeError` on every object under test, so this is corrected to `isinstance(name, str)` to match the assertion message.

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### What should a reviewer concentrate their feedback on?

* Whether muting stderr by default at `verbose < 2` is the desired behavior, or whether it should be opt-in.
* The `names` to `str` correction in `test_create_test_instances_and_names`. It changes what that assert actually checks since it has never truly executed before.
