### PR TITLE
[MNT] remove extraneous material from package wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,24 +144,11 @@ exclude_dirs = ["*/tests/*", "*/testing/*"]
 zip-safe = true
 
 [tool.setuptools.package-data]
-sktime = [
+skbase = [
     "*.csv",
     "*.csv.gz",
-    "*.arff",
-    "*.arff.gz",
     "*.txt",
-    "*.ts",
-    "*.tsv",
 ]
 
 [tool.setuptools.packages.find]
-exclude = [
-    "tests",
-    "tests.*",
-    "docs",
-    "docs.*",
-    "examples",
-    "examples.*",
-    "build_tools",
-    "build_tools.*",
-]
+include = ["skbase", "skbase.*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,4 +155,13 @@ sktime = [
 ]
 
 [tool.setuptools.packages.find]
-exclude = ["tests", "tests.*"]
+exclude = [
+    "tests",
+    "tests.*",
+    "docs",
+    "docs.*",
+    "examples",
+    "examples.*",
+    "build_tools",
+    "build_tools.*",
+]


### PR DESCRIPTION
Mirror of https://github.com/sktime/sktime/issues/10891
Explicitly excludes folders from repository root that should not be shipped with release package wheels:

* `build_tools` (for maintainers only)
* `docs` (for developers with a clone only)
* `examples` (consumption via clone, binder/colab resp online docs only)

Mechanism: changing to explicit include (also future-proof) as opposed to widening exclude statement, in `tool.setuptools.packages.find`.