### PR TITLE
[BUG] roll back state when set_params fails validation

### DIFF
--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -384,40 +384,48 @@ class BaseObject(_FlagManager):
             return self
         valid_params = self.get_params(deep=True)
 
-        # snapshot instance state, to restore it if setting params below raises,
-        # e.g., through a validation failure in __init__ during the reset call.
-        # Without this, a failed set_params can leave self in a state that
-        # __init__ could not have produced, since setattr writes below happen
-        # before that validation runs.
+        # snapshot instance state, to restore it if the reset call below raises,
+        # e.g., through a parameter validation failure in __init__.
+        # Must be taken before the setattr writes below, since those writes are
+        # what leave self in a state that __init__ could not have produced.
+        # This is a shallow copy of the instance __dict__, i.e., it stores
+        # references to attribute values, it does not copy the values themselves.
         prev_state = self.__dict__.copy()
 
         unmatched_keys = []
 
         nested_params = defaultdict(dict)  # grouped by prefix
-        try:
-            for full_key, value in params.items():
-                # split full_key by first occurrence of __, if contains __
-                # "key_without_dblunderscore" -> "key_without_dbl_underscore", None, None
-                # "key__with__dblunderscore" -> "key", "__", "with__dblunderscore"
-                key, delim, sub_key = full_key.partition("__")
-                # if key not recognized, remember for suffix matching
-                if key not in valid_params:
-                    unmatched_keys += [key]
-                # if full_key contained __, collect suffix for component set_params
-                elif delim:
-                    nested_params[key][sub_key] = value
-                # if key is found and did not contain __, set self.key to the value
-                else:
-                    setattr(self, key, value)
-                    valid_params[key] = value
+        for full_key, value in params.items():
+            # split full_key by first occurrence of __, if contains __
+            # "key_without_dblunderscore" -> "key_without_dbl_underscore", None, None
+            # "key__with__dblunderscore" -> "key", "__", "with__dblunderscore"
+            key, delim, sub_key = full_key.partition("__")
+            # if key not recognized, remember for suffix matching
+            if key not in valid_params:
+                unmatched_keys += [key]
+            # if full_key contained __, collect suffix for component set_params
+            elif delim:
+                nested_params[key][sub_key] = value
+            # if key is found and did not contain __, set self.key to the value
+            else:
+                setattr(self, key, value)
+                valid_params[key] = value
 
-            # all matched params have now been set
-            # reset object to clean post-init state with those params
+        # all matched params have now been set
+        # reset object to clean post-init state with those params
+        try:
             self.reset()
-        except Exception:
+        except Exception as e:
+            # restore the pre-call state, then report what happened,
+            # the original exception is chained via "from e"
             self.__dict__.clear()
             self.__dict__.update(prev_state)
-            raise
+            raise RuntimeError(
+                f"Error in {type(self).__name__}.set_params, the parameter values "
+                f"passed were rejected when re-running __init__, which raised "
+                f"{type(e).__name__}: {e}. The object has been restored to its "
+                f"state before the set_params call."
+            ) from e
 
         # recurse in components
         for key, sub_params in nested_params.items():

--- a/skbase/base/_base.py
+++ b/skbase/base/_base.py
@@ -384,28 +384,40 @@ class BaseObject(_FlagManager):
             return self
         valid_params = self.get_params(deep=True)
 
+        # snapshot instance state, to restore it if setting params below raises,
+        # e.g., through a validation failure in __init__ during the reset call.
+        # Without this, a failed set_params can leave self in a state that
+        # __init__ could not have produced, since setattr writes below happen
+        # before that validation runs.
+        prev_state = self.__dict__.copy()
+
         unmatched_keys = []
 
         nested_params = defaultdict(dict)  # grouped by prefix
-        for full_key, value in params.items():
-            # split full_key by first occurrence of __, if contains __
-            # "key_without_dblunderscore" -> "key_without_dbl_underscore", None, None
-            # "key__with__dblunderscore" -> "key", "__", "with__dblunderscore"
-            key, delim, sub_key = full_key.partition("__")
-            # if key not recognized, remember for suffix matching
-            if key not in valid_params:
-                unmatched_keys += [key]
-            # if full_key contained __, collect suffix for component set_params
-            elif delim:
-                nested_params[key][sub_key] = value
-            # if key is found and did not contain __, set self.key to the value
-            else:
-                setattr(self, key, value)
-                valid_params[key] = value
+        try:
+            for full_key, value in params.items():
+                # split full_key by first occurrence of __, if contains __
+                # "key_without_dblunderscore" -> "key_without_dbl_underscore", None, None
+                # "key__with__dblunderscore" -> "key", "__", "with__dblunderscore"
+                key, delim, sub_key = full_key.partition("__")
+                # if key not recognized, remember for suffix matching
+                if key not in valid_params:
+                    unmatched_keys += [key]
+                # if full_key contained __, collect suffix for component set_params
+                elif delim:
+                    nested_params[key][sub_key] = value
+                # if key is found and did not contain __, set self.key to the value
+                else:
+                    setattr(self, key, value)
+                    valid_params[key] = value
 
-        # all matched params have now been set
-        # reset object to clean post-init state with those params
-        self.reset()
+            # all matched params have now been set
+            # reset object to clean post-init state with those params
+            self.reset()
+        except Exception:
+            self.__dict__.clear()
+            self.__dict__.update(prev_state)
+            raise
 
         # recurse in components
         for key, sub_params in nested_params.items():

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -930,8 +930,14 @@ def test_set_params_rolls_back_state_on_invalid_value():
     """
     obj = ValidatingObject(x=5)
 
-    with pytest.raises(ValueError, match="x must be non-negative"):
+    with pytest.raises(RuntimeError, match="restored to its state") as exc_info:
         obj.set_params(x=-1)
+
+    # the exception names the failing object and reports the restore
+    assert "ValidatingObject.set_params" in str(exc_info.value)
+    # the original __init__ exception is chained, not discarded
+    assert isinstance(exc_info.value.__cause__, ValueError)
+    assert "x must be non-negative" in str(exc_info.value.__cause__)
 
     assert obj.x == 5
     assert obj.get_params() == {"x": 5}

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -903,6 +903,48 @@ def test_set_params_with_no_param_to_set_returns_object(
     )
 
 
+class ValidatingObject(BaseObject):
+    """BaseObject whose __init__ writes then validates a parameter.
+
+    Regression fixture for https://github.com/sktime/sktime/issues/10695 :
+    __init__ assigns ``self.x`` before raising, mirroring the common pattern
+    of estimators that write a hyper-parameter to ``self`` ahead of a
+    validation check.
+    """
+
+    def __init__(self, x=1):
+        self.x = x
+        if x < 0:
+            raise ValueError("x must be non-negative")
+        super().__init__()
+
+
+def test_set_params_rolls_back_state_on_invalid_value():
+    """Test a failed set_params leaves the object in its pre-call state.
+
+    A failed set_params previously left self holding the rejected value,
+    since set_params writes parameters to self before reset() re-runs
+    __init__ for validation. A state __init__ could never have produced
+    would then survive the raise, and break get_params, clone and repeated
+    set_params calls from that point on.
+    """
+    obj = ValidatingObject(x=5)
+
+    with pytest.raises(ValueError, match="x must be non-negative"):
+        obj.set_params(x=-1)
+
+    assert obj.x == 5
+    assert obj.get_params() == {"x": 5}
+
+    # clone should still work off the pre-call state
+    cloned = obj.clone()
+    assert cloned.get_params() == {"x": 5}
+
+    # a subsequent valid set_params call should still work normally
+    obj.set_params(x=9)
+    assert obj.get_params() == {"x": 9}
+
+
 # This section tests the clone functionality
 # These have been adapted from sklearn's tests of clone to use the clone
 # method that is included as part of the BaseObject interface


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes https://github.com/sktime/sktime/issues/10695. See also https://github.com/sktime/sktime/pull/10821, an earlier attempt at this issue that patched `set_params` on the `sktime` side and was closed unmerged, since the bug is in `BaseObject.set_params` here in `skbase`, not in `sktime`.

#### What does this implement/fix? Explain your changes.

`BaseObject.set_params` writes new parameter values to `self` via `setattr` before calling `self.reset()`, which is what actually re-runs `__init__` to validate them. If `__init__` rejects a value, the raise happens after the write, so the rejected value survives on `self` -- a state `__init__` could never have produced. `get_params`, `clone`, and any later `set_params` call then operate on that invalid state.

```python
class Validated(BaseObject):
    def __init__(self, x=1):
        self.x = x
        if x < 0:
            raise ValueError("x must be >= 0")
        super().__init__()

v = Validated(x=5)
v.set_params(x=-1)   # raises ValueError
v.x                   # -1, before this fix -- the rejected value stuck
```

Fix snapshots `self.__dict__` before the parameter-writing loop in `set_params`, and restores it if anything in that loop or the following `self.reset()` call raises, then re-raises the original exception. Confirmed against the estimator that surfaced this in `sktime` (`DilationMappingTransformer`): `set_params(dilation=0)` now leaves `dilation` at its prior valid value instead of `0`, and `clone()` succeeds afterward.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether snapshotting/restoring `self.__dict__` is the right mechanism, versus validating before writing to `self` in the first place -- the issue write-up considered both directions and this seemed the smaller, more general change, since it doesn't require touching every `__init__`.
- The existing `test_get_params_after_set_params` test in `test_base.py` already asserts rollback semantics under fuzz values, but the fixture class it uses (`Parent`) never raises in `__init__`, so that assertion was never actually exercised. Added a new test with a fixture that does validate, `test_set_params_rolls_back_state_on_invalid_value`.

#### Any other comments?

An LLM was used as a search and navigation tool to help trace the bug to its root cause in `set_params`/`reset()` and to draft this description. Every claim above -- the repro, the root cause, the before/after behavior, and the test counts -- was produced by running the code locally on both sides of the fix, including a run of the new test against the pre-fix source to confirm it fails without the change.

#### PR checklist

##### For all contributions
- [x] I've reviewed the project documentation on [contributing](https://skbase.readthedocs.io/en/latest/contribute.html)
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skbase/blob/main/.all-contributorsrc).
- [x] The PR title starts with either [ENH], [CI/CD], [MNT], [DOC], or [BUG] indicating whether
  the PR topic is related to enhancement, CI/CD, maintenance, documentation, or a bug.

##### For code contributions
- [x] Unit tests have been added covering code functionality
- [x] Appropriate docstrings have been added (see [documentation standards](https://skbase.readthedocs.io/en/latest/contribute/development/developer_guide/creating_docs.html))
- [ ] New public functionality has been added to the API Reference
